### PR TITLE
Fix git repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Chris Pettitt <chris@samsarin.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cpettitt/dagre.git"
+    "url": "https://github.com/cpettitt/graphlib.git"
   },
   "license": "MIT",
   "testling": {


### PR DESCRIPTION
Fix URL to git repo so the npm publish page has the right info.
