### PR TITLE
Corrected description of DGraph sinks()

### DIFF
--- a/doc/include/graph/Digraph-sinks.jade
+++ b/doc/include/graph/Digraph-sinks.jade
@@ -1,7 +1,7 @@
 h3(id="#{Graph}-sinks") #{graph}.sinks()
 :markdown
     Returns the ids of all nodes that are in this #{graph} that are sinks. A
-    sink in a directed graph is a node that has no in-edges.
+    sink in a directed graph is a node that has no out-edges.
 
     ```js
     #{graph}.addNode(1);


### PR DESCRIPTION
Was incorrectly describing a sink as a node with no
in edges. Changed the description to say that a sink
is a node with no out edges
