### PR TITLE
Move to selective lodash import

### DIFF
--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -4,7 +4,24 @@ var lodash;
 
 if (typeof require === "function") {
   try {
-    lodash = require("lodash");
+    lodash = {
+      clone: require("lodash/clone"),
+      constant: require("lodash/constant"),
+      each: require("lodash/each"),
+      filter: require("lodash/filter"),
+      has:  require("lodash/has"),
+      isArray: require("lodash/isArray"),
+      isEmpty: require("lodash/isEmpty"),
+      isFunction: require("lodash/isFunction"),
+      isUndefined: require("lodash/isUndefined"),
+      keys: require("lodash/keys"),
+      map: require("lodash/map"),
+      reduce: require("lodash/reduce"),
+      size: require("lodash/size"),
+      transform: require("lodash/transform"),
+      union: require("lodash/union"),
+      values: require("lodash/values")
+    };
   } catch (e) {}
 }
 


### PR DESCRIPTION
Greatly reduces build sizes:
graphlib.js: 557K => 190K
graphlib.min.js: 489K => 169K

NOTE: This is the minimum change for this while still allowing an external lodash and not usin ES5 native functions that would lead to an even smaller build.