### PR TITLE
Graph reduce

### DIFF
--- a/lib/alg/dfs.js
+++ b/lib/alg/dfs.js
@@ -1,42 +1,16 @@
-var _ = require("../lodash");
+var reduce = require("./reduce");
 
 module.exports = dfs;
 
 /*
- * A helper that preforms a pre- or post-order traversal on the input graph
- * and returns the nodes in the order they were visited. If the graph is
- * undirected then this algorithm will navigate using neighbors. If the graph
- * is directed then this algorithm will navigate using successors.
+ * Pre- or post-order traversal on the input graph.
+ * Returns an array of the nodes in the order they were visited.
  *
  * Order must be one of "pre" or "post".
  */
 function dfs(g, vs, order) {
-  if (!_.isArray(vs)) {
-    vs = [vs];
-  }
-
-  var navigation = (g.isDirected() ? g.successors : g.neighbors).bind(g);
-
-  var acc = [],
-      visited = {};
-  _.each(vs, function(v) {
-    if (!g.hasNode(v)) {
-      throw new Error("Graph does not have node: " + v);
-    }
-
-    doDfs(g, v, order === "post", visited, navigation, acc);
-  });
-  return acc;
-}
-
-function doDfs(g, v, postorder, visited, navigation, acc) {
-  if (!_.has(visited, v)) {
-    visited[v] = true;
-
-    if (!postorder) { acc.push(v); }
-    _.each(navigation(v), function(w) {
-      doDfs(g, w, postorder, visited, navigation, acc);
-    });
-    if (postorder) { acc.push(v); }
-  }
+  return reduce(g, vs, order, function (acc, v) {
+    acc.push(v);
+    return acc;
+  }, []);
 }

--- a/lib/alg/index.js
+++ b/lib/alg/index.js
@@ -8,6 +8,7 @@ module.exports = {
   postorder: require("./postorder"),
   preorder: require("./preorder"),
   prim: require("./prim"),
+  reduce: require("./reduce"),
   tarjan: require("./tarjan"),
   topsort: require("./topsort")
 };

--- a/lib/alg/reduce.js
+++ b/lib/alg/reduce.js
@@ -1,0 +1,42 @@
+var _ = require("../lodash");
+
+module.exports = reduce;
+
+/*
+ * A helper that preforms a pre- or post-order traversal on the input graph
+ * and processes the nodes in the order they are visited. If the graph is
+ * undirected then this algorithm will navigate using neighbors. If the graph
+ * is directed then this algorithm will navigate using successors.
+ *
+ * Order must be one of "pre" or "post".
+ */
+function reduce(g, vs, order, fn, acc) {
+  if (!_.isArray(vs)) {
+    vs = [vs];
+  }
+
+  var navigation = (g.isDirected() ? g.successors : g.neighbors).bind(g);
+
+  var visited = {};
+  _.each(vs, function(v) {
+    if (!g.hasNode(v)) {
+      throw new Error("Graph does not have node: " + v);
+    }
+
+    acc = doReduce(g, v, order === "post", visited, navigation, fn, acc);
+  });
+  return acc;
+}
+
+function doReduce(g, v, postorder, visited, navigation, fn, acc) {
+  if (!_.has(visited, v)) {
+    visited[v] = true;
+
+    if (!postorder) { acc = fn(acc, v); }
+    _.each(navigation(v), function(w) {
+      acc = doReduce(g, w, postorder, visited, navigation, fn, acc);
+    });
+    if (postorder) { acc = fn(acc, v); }
+  }
+  return acc;
+}

--- a/test/alg/reduce-test.js
+++ b/test/alg/reduce-test.js
@@ -1,0 +1,45 @@
+var expect = require("../chai").expect,
+    Graph = require("../..").Graph,
+    reduce = require("../..").alg.reduce;
+
+describe("alg.reduce", function() {
+  it("returns the initial accumulator value when the graph is empty",
+    function() {
+      var g = new Graph();
+
+      expect(reduce(g, [], "pre", function(a, b) {
+        return a + "wrong" + b;
+      }, 0)).to.eql(0);
+    }
+  );
+
+  it("applies the accumulator function to all nodes in the graph", function() {
+    var g = new Graph({ directed: false });
+    g.setPath(["1", "2", "3", "5", "7"]);
+    g.setPath(["2", "5", "11", "13"]);
+
+    expect(reduce(g, "2", "pre", function(a, b) {
+      return Number(a) + Number(b);
+    }, 0)).to.eql(42);
+  });
+
+  it("traverses the graph in pre order", function() {
+    var g = new Graph({ directed: false });
+    g.setPath(["1", "2", "3", "5", "7"]);
+    g.setPath(["2", "5", "11", "13"]);
+
+    expect(reduce(g, "2", "pre", function(a, b) {
+      return a + b + "-";
+    }, "")).to.eql("2-1-3-5-11-13-7-");
+  });
+
+  it("traverses the graph in post order", function() {
+    var g = new Graph({ directed: false });
+    g.setPath(["1", "2", "3", "5", "7"]);
+    g.setPath(["2", "5", "11", "13"]);
+
+    expect(reduce(g, "2", "post", function(a, b) {
+      return a + b + "-";
+    }, "")).to.eql("1-13-11-7-5-3-2-");
+  });
+});


### PR DESCRIPTION
This patch introduces the `reduce` algorithm which performs a `dfs` but processes the graph using an arbitrary function accumulator. pre-order and post-order are still supported. DFS has been rewritten using the new `reduce` function.

Fix #62