### PR TITLE
feat: switch to lodash 'dot' packages

### DIFF
--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -6,22 +6,22 @@ var lodash;
 if (typeof require === "function") {
   try {
     lodash = {
-      clone: require("lodash/clone"),
-      constant: require("lodash/constant"),
-      each: require("lodash/each"),
-      filter: require("lodash/filter"),
-      has:  require("lodash/has"),
-      isArray: require("lodash/isArray"),
-      isEmpty: require("lodash/isEmpty"),
-      isFunction: require("lodash/isFunction"),
-      isUndefined: require("lodash/isUndefined"),
-      keys: require("lodash/keys"),
-      map: require("lodash/map"),
-      reduce: require("lodash/reduce"),
-      size: require("lodash/size"),
-      transform: require("lodash/transform"),
-      union: require("lodash/union"),
-      values: require("lodash/values")
+      clone: require("lodash.clone"),
+      constant: require("lodash.constant"),
+      each: require("lodash.foreach"),
+      filter: require("lodash.filter"),
+      has:  require("lodash.has"),
+      isArray: require("lodash.isarray"),
+      isEmpty: require("lodash.isempty"),
+      isFunction: require("lodash.isfunction"),
+      isUndefined: require("lodash.isundefined"),
+      keys: require("lodash.keys"),
+      map: require("lodash.map"),
+      reduce: require("lodash.reduce"),
+      size: require("lodash.size"),
+      transform: require("lodash.transform"),
+      union: require("lodash.union"),
+      values: require("lodash.values")
     };
   } catch (e) {
     // continue regardless of error

--- a/package.json
+++ b/package.json
@@ -15,7 +15,22 @@
     "algorithms"
   ],
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash.clone": "^4.5.0",
+    "lodash.constant": "^3.0.0",
+    "lodash.filter": "^4.6.0",
+    "lodash.foreach": "^4.5.0",
+    "lodash.has": "^4.5.2",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isempty": "^4.4.0",
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isundefined": "^3.0.1",
+    "lodash.keys": "^4.2.0",
+    "lodash.map": "^4.6.0",
+    "lodash.reduce": "^4.6.0",
+    "lodash.size": "^4.2.0",
+    "lodash.transform": "^4.6.0",
+    "lodash.union": "^4.6.0",
+    "lodash.values": "^4.3.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",


### PR DESCRIPTION
This reduces the amount of `lodash`, and the associated vulnerabilities, that the megapackage pulls in at runtime.

Fixes #70.

`make dist` passes for me, but I have not included the updated `dist/`/`bower` files in this PR. Is that expected, or is it handled by the release process only?

I don't fully follow the reasoning that led to stopping after most of the work was done in #86, nearly two years ago.

I understand that transpilation was not a popular idea. A number of these lodash packages are for very old features. I guess supporting IE11 is still a goal, because it still shows as non-zero market share on some measurements. Personally, I find it very hard to work with a project targeting 2012 JS in TYOOL 2020.