### PR TITLE
fix: interop default for lodash-es alias

### DIFF
--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -1,27 +1,29 @@
 // eslint-disable-next-line no-redeclare
 /* global window */
 
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
 var lodash;
 
 if (typeof require === "function") {
   try {
     lodash = {
-      clone: require("lodash/clone"),
-      constant: require("lodash/constant"),
-      each: require("lodash/each"),
-      filter: require("lodash/filter"),
-      has:  require("lodash/has"),
-      isArray: require("lodash/isArray"),
-      isEmpty: require("lodash/isEmpty"),
-      isFunction: require("lodash/isFunction"),
-      isUndefined: require("lodash/isUndefined"),
-      keys: require("lodash/keys"),
-      map: require("lodash/map"),
-      reduce: require("lodash/reduce"),
-      size: require("lodash/size"),
-      transform: require("lodash/transform"),
-      union: require("lodash/union"),
-      values: require("lodash/values")
+      clone: _interopDefault(require("lodash/clone")),
+      constant: _interopDefault(require("lodash/constant")),
+      each: _interopDefault(require("lodash/each")),
+      filter: _interopDefault(require("lodash/filter")),
+      has:  _interopDefault(require("lodash/has")),
+      isArray: _interopDefault(require("lodash/isArray")),
+      isEmpty: _interopDefault(require("lodash/isEmpty")),
+      isFunction: _interopDefault(require("lodash/isFunction")),
+      isUndefined: _interopDefault(require("lodash/isUndefined")),
+      keys: _interopDefault(require("lodash/keys")),
+      map: _interopDefault(require("lodash/map")),
+      reduce: _interopDefault(require("lodash/reduce")),
+      size: _interopDefault(require("lodash/size")),
+      transform: _interopDefault(require("lodash/transform")),
+      union: _interopDefault(require("lodash/union")),
+      values: _interopDefault(require("lodash/values"))
     };
   } catch (e) {
     // continue regardless of error


### PR DESCRIPTION
It is common to replace `lodash` with `lodash-es` with webpack alias to reduce bundle size, but `require('lodash-es/x').default` is required, so it would be great to add `_interopDefault` which is taken from `rollup` here.

cc @lutzroeder 