### PR TITLE
Recursive DFS implementations

### DIFF
--- a/lib/alg/dfs.ts
+++ b/lib/alg/dfs.ts
@@ -1,4 +1,4 @@
-import * as _  from "lodash";
+import * as _ from "lodash";
 import { Graph } from "../graph";
 
 type Order = "pre"|"post";
@@ -31,13 +31,33 @@ export function dfs(g: Graph, vs, order: Order) {
 }
 
 function doDfs(g, v, postorder, visited, navigation, acc) {
-  if (!_.has(visited, v)) {
-    visited[v] = true;
-
-    if (!postorder) { acc.push(v); }
-    _.each(navigation(v), function(w) {
-      doDfs(g, w, postorder, visited, navigation, acc);
-    });
-    if (postorder) { acc.push(v); }
+  if (postorder) {
+    var stack = [[v, false]];
+    while (stack.length > 0) {
+      var curr = stack.pop();
+      if (curr[1]) {
+        acc.push(curr[0]);
+      } else {
+        if (!_.has(visited, curr[0])) {
+          visited[curr[0]] = true;
+          stack.push([curr[0], true]);
+          _.forEachRight(navigation(curr[0]), function(w) {
+            stack.push([w, false]);
+          });
+        }
+      }
+    }
+  } else {
+    var stack = [v];
+    while (stack.length > 0) {
+      var curr = stack.pop();
+      if (!_.has(visited, curr)) {
+        visited[curr];
+        acc.push(curr);
+        _.forEachRight(navigation(curr), function(w) {
+          stack.push(w);
+        });
+      }
+    }
   }
 }

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -21,7 +21,8 @@ if (typeof require === "function") {
       size: require("lodash/size"),
       transform: require("lodash/transform"),
       union: require("lodash/union"),
-      values: require("lodash/values")
+      values: require("lodash/values"),
+      forEachRight: require("lodash/forEachRight"),
     };
   } catch (e) {
     // continue regardless of error


### PR DESCRIPTION
This issue corresponds to issue: #147.
Relates to this PR: dagrejs/dagre#328.

If I recall correctly, every recursive function can be rewritten in iterative fashion. I took the liberty to rewrite the recursive DFS function in `lib\alg\dfs.ts` to an iterative DFS function. This also got rid of my `max call stack size` errors. I can now have **dagre** layouts for 10.000 node graphs.

PS: I was not able to run the make file to run tests and styling because I work on Windows.