### PR TITLE
Update to support ESM

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+  "plugins": ["@babel/plugin-transform-export-namespace-from", "@babel/plugin-transform-modules-commonjs", "add-module-exports"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,9 @@
     "mocha": true
   },
   "parserOptions": {
-    "ecmaVersion": "latest"
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "allowImportExportEverywhere": true
   },
   "env": {
     "es6": true,

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,13 @@ lint:
 	@$(JSHINT) $(JSHINT_OPTS) $(filter-out node_modules, $?)
 	@$(ESLINT) $(MJS_FILES) $(TEST_FILES)
 
-$(BUILD_DIR)/$(MOD).js: index.js $(CJS_FILES) | unit-test
+$(BUILD_DIR)/$(MOD).js: $(CJS_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ -s graphlib
 
 $(BUILD_DIR)/$(MOD).min.js: $(BUILD_DIR)/$(MOD).js
 	@$(UGLIFY) $< --comments '@license' > $@
 
-$(BUILD_DIR)/$(MOD).core.js: index.js $(CJS_FILES) | unit-test
+$(BUILD_DIR)/$(MOD).core.js: $(CJS_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ --no-bundle-external -s graphlib
 
 $(BUILD_DIR)/$(MOD).core.min.js: $(BUILD_DIR)/$(MOD).core.js

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DIST_DIR = dist
 
 MJS_FILES = $(shell find mjs-lib -type f -name '*.js')
 # CJS_FILES are based off mjs files.
-CJS_FILES = $(shell find mjs-lib -type f -name '*.js' -printf lib/%P\\n)
+CJS_FILES = index.js $(shell find mjs-lib -type f -name '*.js' -printf lib/%P\\n)
 TEST_FILES = $(shell find test -type f -name '*.js' | grep -v 'bundle-test.js' | grep -v 'test-main.js')
 BUILD_FILES = $(addprefix $(BUILD_DIR)/, \
 						$(MOD).js $(MOD).min.js \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ BUILD_DIR = build
 COVERAGE_DIR = ./.nyc_output
 DIST_DIR = dist
 
-SRC_FILES = index.js lib/version.js $(shell find lib -type f -name '*.js')
+# Why is this doubled up?
+SRC_FILES = lib/index.js lib/version.js $(shell find lib -type f -name '*.js')
 TEST_FILES = $(shell find test -type f -name '*.js' | grep -v 'bundle-test.js' | grep -v 'test-main.js')
 BUILD_FILES = $(addprefix $(BUILD_DIR)/, \
 						$(MOD).js $(MOD).min.js \
@@ -24,7 +25,7 @@ BUILD_FILES = $(addprefix $(BUILD_DIR)/, \
 
 DIRS = $(BUILD_DIR)
 
-.PHONY: all bench clean browser-test unit-test test dist
+.PHONY: all bench clean browser-test unit-test test dist convert
 
 all: unit-test lint
 
@@ -82,3 +83,8 @@ clean:
 node_modules: package.json
 	@$(NPM) install
 	@touch $@
+
+convert: mjs-lib/*.js mjs-lib/**/*.js
+	rm -rf lib; mkdir lib
+	for f in mjs-lib/**/*.js mjs-lib/*.js; do echo "$${f} > lib$${f/mjs-lib/}"; npx babel "$${f}" -o "lib$${f/mjs-lib/}"; done
+

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,6 @@ lib/%.js: mjs-lib/%.js
 	npx babel "$<" -o "$@"
 
 convert-clean:
-	rsync --ignore-existing --delete -r mjs-lib/ lib/
+	rsync --existing --ignore-existing --delete -r mjs-lib/ lib/
 
-convert: $(CJS_FILES)
+convert: convert-clean $(CJS_FILES)

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ $(DIRS):
 test: unit-test browser-test
 
 unit-test: $(SRC_FILES) $(TEST_FILES) node_modules | $(BUILD_DIR)
-	$(NYC) $(MOCHA) --dir $(COVERAGE_DIR) -- $(MOCHA_OPTS) $(TEST_FILES) || $(MOCHA) $(MOCHA_OPTS) $(TEST_FILES)
+	-$(NYC) $(MOCHA) --dir $(COVERAGE_DIR) -- $(MOCHA_OPTS) $(TEST_FILES) || $(MOCHA) $(MOCHA_OPTS) $(TEST_FILES)
 
 browser-test: $(BUILD_DIR)/$(MOD).js $(BUILD_DIR)/$(MOD).core.js
-	$(KARMA) start --single-run $(KARMA_OPTS)
-	$(KARMA) start karma.core.conf.js --single-run $(KARMA_OPTS)
+	-$(KARMA) start --single-run $(KARMA_OPTS)
+	-$(KARMA) start karma.core.conf.js --single-run $(KARMA_OPTS)
 
 bower.json: package.json src/release/make-bower.json.js
 	@src/release/make-bower.json.js > $@

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DIST_DIR = dist
 
 MJS_FILES = $(shell find mjs-lib -type f -name '*.js')
 # CJS_FILES are based off mjs files.
-CJS_FILES = index.js $(shell find mjs-lib -type f -name '*.js' -printf lib/%P\\n)
+CJS_FILES = $(shell find mjs-lib -type f -name '*.js' -printf lib/%P\\n)
 TEST_FILES = $(shell find test -type f -name '*.js' | grep -v 'bundle-test.js' | grep -v 'test-main.js')
 BUILD_FILES = $(addprefix $(BUILD_DIR)/, \
 						$(MOD).js $(MOD).min.js \
@@ -41,7 +41,7 @@ $(DIRS):
 
 test: unit-test browser-test
 
-unit-test: convert $(CJS_FILES) $(TEST_FILES) node_modules | $(BUILD_DIR)
+unit-test: convert index.js $(CJS_FILES) $(TEST_FILES) node_modules | $(BUILD_DIR)
 	-$(NYC) $(MOCHA) --dir $(COVERAGE_DIR) -- $(MOCHA_OPTS) $(TEST_FILES) || $(MOCHA) $(MOCHA_OPTS) $(TEST_FILES)
 
 browser-test: $(BUILD_DIR)/$(MOD).js $(BUILD_DIR)/$(MOD).core.js
@@ -58,13 +58,13 @@ lint:
 	@$(JSHINT) $(JSHINT_OPTS) $(filter-out node_modules, $?)
 	@$(ESLINT) $(MJS_FILES) $(TEST_FILES)
 
-$(BUILD_DIR)/$(MOD).js: $(CJS_FILES) | unit-test
+$(BUILD_DIR)/$(MOD).js: index.js $(CJS_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ -s graphlib
 
 $(BUILD_DIR)/$(MOD).min.js: $(BUILD_DIR)/$(MOD).js
 	@$(UGLIFY) $< --comments '@license' > $@
 
-$(BUILD_DIR)/$(MOD).core.js: $(CJS_FILES) | unit-test
+$(BUILD_DIR)/$(MOD).core.js: index.js $(CJS_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ --no-bundle-external -s graphlib
 
 $(BUILD_DIR)/$(MOD).core.min.js: $(BUILD_DIR)/$(MOD).core.js

--- a/Makefile
+++ b/Makefile
@@ -86,5 +86,5 @@ node_modules: package.json
 
 convert: mjs-lib/*.js mjs-lib/**/*.js
 	rm -rf lib; mkdir lib
-	for f in mjs-lib/**/*.js mjs-lib/*.js; do echo "$${f} > lib$${f/mjs-lib/}"; npx babel "$${f}" -o "lib$${f/mjs-lib/}"; done
+	for f in mjs-lib/**/*.js mjs-lib/*.js; do echo "$${f} > lib$${f/mjs-lib/}"; npx babel "$${f}" -o "lib$${f/mjs-lib/}" || exit 1; done
 

--- a/lib/alg/components.js
+++ b/lib/alg/components.js
@@ -1,6 +1,4 @@
-module.exports = components;
-
-function components(g) {
+export default function components(g) {
   var visited = {};
   var cmpts = [];
   var cmpt;

--- a/lib/alg/components.js
+++ b/lib/alg/components.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = components;
+exports.default = components;
 function components(g) {
   var visited = {};
   var cmpts = [];
@@ -24,3 +24,4 @@ function components(g) {
   });
   return cmpts;
 }
+module.exports = exports.default;

--- a/lib/alg/dfs.js
+++ b/lib/alg/dfs.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = dfs;
+exports.default = dfs;
 /*
  * A helper that preforms a pre- or post-order traversal on the input graph
  * and returns the nodes in the order they were visited. If the graph is
@@ -16,15 +16,11 @@ function dfs(g, vs, order) {
   if (!Array.isArray(vs)) {
     vs = [vs];
   }
-  var navigation = g.isDirected() ? function (v) {
-    return g.successors(v);
-  } : function (v) {
-    return g.neighbors(v);
-  };
+  var navigation = g.isDirected() ? v => g.successors(v) : v => g.neighbors(v);
   var orderFunc = order === "post" ? postOrderDfs : preOrderDfs;
   var acc = [];
   var visited = {};
-  vs.forEach(function (v) {
+  vs.forEach(v => {
     if (!g.hasNode(v)) {
       throw new Error("Graph does not have node: " + v);
     }
@@ -42,9 +38,7 @@ function postOrderDfs(v, navigation, visited, acc) {
       if (!visited.hasOwnProperty(curr[0])) {
         visited[curr[0]] = true;
         stack.push([curr[0], true]);
-        forEachRight(navigation(curr[0]), function (w) {
-          return stack.push([w, false]);
-        });
+        forEachRight(navigation(curr[0]), w => stack.push([w, false]));
       }
     }
   }
@@ -56,9 +50,7 @@ function preOrderDfs(v, navigation, visited, acc) {
     if (!visited.hasOwnProperty(curr)) {
       visited[curr] = true;
       acc.push(curr);
-      forEachRight(navigation(curr), function (w) {
-        return stack.push(w);
-      });
+      forEachRight(navigation(curr), w => stack.push(w));
     }
   }
 }
@@ -69,3 +61,4 @@ function forEachRight(array, iteratee) {
   }
   return array;
 }
+module.exports = exports.default;

--- a/lib/alg/dfs.js
+++ b/lib/alg/dfs.js
@@ -1,5 +1,3 @@
-module.exports = dfs;
-
 /*
  * A helper that preforms a pre- or post-order traversal on the input graph
  * and returns the nodes in the order they were visited. If the graph is
@@ -8,7 +6,7 @@ module.exports = dfs;
  *
  * If the order is not "post", it will be treated as "pre".
  */
-function dfs(g, vs, order) {
+export default function dfs(g, vs, order) {
   if (!Array.isArray(vs)) {
     vs = [vs];
   }

--- a/lib/alg/dijkstra-all.js
+++ b/lib/alg/dijkstra-all.js
@@ -1,9 +1,14 @@
-import { default as dijkstra } from "./dijkstra.js";
+"use strict";
 
-
-export default function dijkstraAll(g, weightFunc, edgeFunc) {
-  return g.nodes().reduce(function(acc, v) {
-    acc[v] = dijkstra(g, v, weightFunc, edgeFunc);
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = dijkstraAll;
+var _dijkstra = _interopRequireDefault(require("./dijkstra.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function dijkstraAll(g, weightFunc, edgeFunc) {
+  return g.nodes().reduce(function (acc, v) {
+    acc[v] = (0, _dijkstra["default"])(g, v, weightFunc, edgeFunc);
     return acc;
   }, {});
 }

--- a/lib/alg/dijkstra-all.js
+++ b/lib/alg/dijkstra-all.js
@@ -1,8 +1,7 @@
-var dijkstra = require("./dijkstra");
+import default as dijkstra from "./dijkstra.js";
 
-module.exports = dijkstraAll;
 
-function dijkstraAll(g, weightFunc, edgeFunc) {
+export default function dijkstraAll(g, weightFunc, edgeFunc) {
   return g.nodes().reduce(function(acc, v) {
     acc[v] = dijkstra(g, v, weightFunc, edgeFunc);
     return acc;

--- a/lib/alg/dijkstra-all.js
+++ b/lib/alg/dijkstra-all.js
@@ -3,12 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = dijkstraAll;
+exports.default = dijkstraAll;
 var _dijkstra = _interopRequireDefault(require("./dijkstra.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function dijkstraAll(g, weightFunc, edgeFunc) {
   return g.nodes().reduce(function (acc, v) {
-    acc[v] = (0, _dijkstra["default"])(g, v, weightFunc, edgeFunc);
+    acc[v] = (0, _dijkstra.default)(g, v, weightFunc, edgeFunc);
     return acc;
   }, {});
 }
+module.exports = exports.default;

--- a/lib/alg/dijkstra-all.js
+++ b/lib/alg/dijkstra-all.js
@@ -1,4 +1,4 @@
-import default as dijkstra from "./dijkstra.js";
+import { default as dijkstra } from "./dijkstra.js";
 
 
 export default function dijkstraAll(g, weightFunc, edgeFunc) {

--- a/lib/alg/dijkstra.js
+++ b/lib/alg/dijkstra.js
@@ -3,12 +3,10 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = dijkstra;
+exports.default = dijkstra;
 var _priorityQueue = _interopRequireDefault(require("../data/priority-queue.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-var DEFAULT_WEIGHT_FUNC = function DEFAULT_WEIGHT_FUNC() {
-  return 1;
-};
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var DEFAULT_WEIGHT_FUNC = () => 1;
 function dijkstra(g, source, weightFn, edgeFn) {
   return runDijkstra(g, String(source), weightFn || DEFAULT_WEIGHT_FUNC, edgeFn || function (v) {
     return g.outEdges(v);
@@ -16,9 +14,9 @@ function dijkstra(g, source, weightFn, edgeFn) {
 }
 function runDijkstra(g, source, weightFn, edgeFn) {
   var results = {};
-  var pq = new _priorityQueue["default"]();
+  var pq = new _priorityQueue.default();
   var v, vEntry;
-  var updateNeighbors = function updateNeighbors(edge) {
+  var updateNeighbors = function (edge) {
     var w = edge.v !== v ? edge.v : edge.w;
     var wEntry = results[w];
     var weight = weightFn(edge);
@@ -49,3 +47,4 @@ function runDijkstra(g, source, weightFn, edgeFn) {
   }
   return results;
 }
+module.exports = exports.default;

--- a/lib/alg/dijkstra.js
+++ b/lib/alg/dijkstra.js
@@ -1,52 +1,51 @@
-import { default as PriorityQueue } from "../data/priority-queue.js";
+"use strict";
 
-
-var DEFAULT_WEIGHT_FUNC = () => 1;
-
-export default function dijkstra(g, source, weightFn, edgeFn) {
-  return runDijkstra(g, String(source),
-    weightFn || DEFAULT_WEIGHT_FUNC,
-    edgeFn || function(v) { return g.outEdges(v); });
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = dijkstra;
+var _priorityQueue = _interopRequireDefault(require("../data/priority-queue.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+var DEFAULT_WEIGHT_FUNC = function DEFAULT_WEIGHT_FUNC() {
+  return 1;
+};
+function dijkstra(g, source, weightFn, edgeFn) {
+  return runDijkstra(g, String(source), weightFn || DEFAULT_WEIGHT_FUNC, edgeFn || function (v) {
+    return g.outEdges(v);
+  });
 }
-
 function runDijkstra(g, source, weightFn, edgeFn) {
   var results = {};
-  var pq = new PriorityQueue();
+  var pq = new _priorityQueue["default"]();
   var v, vEntry;
-
-  var updateNeighbors = function(edge) {
+  var updateNeighbors = function updateNeighbors(edge) {
     var w = edge.v !== v ? edge.v : edge.w;
     var wEntry = results[w];
     var weight = weightFn(edge);
     var distance = vEntry.distance + weight;
-
     if (weight < 0) {
-      throw new Error("dijkstra does not allow negative edge weights. " +
-                      "Bad edge: " + edge + " Weight: " + weight);
+      throw new Error("dijkstra does not allow negative edge weights. " + "Bad edge: " + edge + " Weight: " + weight);
     }
-
     if (distance < wEntry.distance) {
       wEntry.distance = distance;
       wEntry.predecessor = v;
       pq.decrease(w, distance);
     }
   };
-
-  g.nodes().forEach(function(v) {
+  g.nodes().forEach(function (v) {
     var distance = v === source ? 0 : Number.POSITIVE_INFINITY;
-    results[v] = { distance: distance };
+    results[v] = {
+      distance: distance
+    };
     pq.add(v, distance);
   });
-
   while (pq.size() > 0) {
     v = pq.removeMin();
     vEntry = results[v];
     if (vEntry.distance === Number.POSITIVE_INFINITY) {
       break;
     }
-
     edgeFn(v).forEach(updateNeighbors);
   }
-
   return results;
 }

--- a/lib/alg/dijkstra.js
+++ b/lib/alg/dijkstra.js
@@ -1,4 +1,4 @@
-import default as PriorityQueue from "../data/priority-queue.js";
+import { default as PriorityQueue } from "../data/priority-queue.js";
 
 
 var DEFAULT_WEIGHT_FUNC = () => 1;

--- a/lib/alg/dijkstra.js
+++ b/lib/alg/dijkstra.js
@@ -1,10 +1,9 @@
-var PriorityQueue = require("../data/priority-queue");
+import default as PriorityQueue from "../data/priority-queue.js";
 
-module.exports = dijkstra;
 
 var DEFAULT_WEIGHT_FUNC = () => 1;
 
-function dijkstra(g, source, weightFn, edgeFn) {
+export default function dijkstra(g, source, weightFn, edgeFn) {
   return runDijkstra(g, String(source),
     weightFn || DEFAULT_WEIGHT_FUNC,
     edgeFn || function(v) { return g.outEdges(v); });

--- a/lib/alg/find-cycles.js
+++ b/lib/alg/find-cycles.js
@@ -3,11 +3,12 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = findCycles;
+exports.default = findCycles;
 var _tarjan = _interopRequireDefault(require("./tarjan.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function findCycles(g) {
-  return (0, _tarjan["default"])(g).filter(function (cmpt) {
+  return (0, _tarjan.default)(g).filter(function (cmpt) {
     return cmpt.length > 1 || cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]);
   });
 }
+module.exports = exports.default;

--- a/lib/alg/find-cycles.js
+++ b/lib/alg/find-cycles.js
@@ -1,7 +1,13 @@
-import { default as tarjan } from "./tarjan.js";
+"use strict";
 
-export default function findCycles(g) {
-  return tarjan(g).filter(function(cmpt) {
-    return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = findCycles;
+var _tarjan = _interopRequireDefault(require("./tarjan.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function findCycles(g) {
+  return (0, _tarjan["default"])(g).filter(function (cmpt) {
+    return cmpt.length > 1 || cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]);
   });
 }

--- a/lib/alg/find-cycles.js
+++ b/lib/alg/find-cycles.js
@@ -1,8 +1,6 @@
-var tarjan = require("./tarjan");
+import default as tarjan from "./targan.js";
 
-module.exports = findCycles;
-
-function findCycles(g) {
+export default function findCycles(g) {
   return tarjan(g).filter(function(cmpt) {
     return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));
   });

--- a/lib/alg/find-cycles.js
+++ b/lib/alg/find-cycles.js
@@ -1,4 +1,4 @@
-import default as tarjan from "./targan.js";
+import { default as tarjan } from "./tarjan.js";
 
 export default function findCycles(g) {
   return tarjan(g).filter(function(cmpt) {

--- a/lib/alg/floyd-warshall.js
+++ b/lib/alg/floyd-warshall.js
@@ -1,8 +1,6 @@
-module.exports = floydWarshall;
-
 var DEFAULT_WEIGHT_FUNC = () => 1;
 
-function floydWarshall(g, weightFn, edgeFn) {
+export default function floydWarshall(g, weightFn, edgeFn) {
   return runFloydWarshall(g,
     weightFn || DEFAULT_WEIGHT_FUNC,
     edgeFn || function(v) { return g.outEdges(v); });

--- a/lib/alg/floyd-warshall.js
+++ b/lib/alg/floyd-warshall.js
@@ -1,35 +1,46 @@
-var DEFAULT_WEIGHT_FUNC = () => 1;
+"use strict";
 
-export default function floydWarshall(g, weightFn, edgeFn) {
-  return runFloydWarshall(g,
-    weightFn || DEFAULT_WEIGHT_FUNC,
-    edgeFn || function(v) { return g.outEdges(v); });
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = floydWarshall;
+var DEFAULT_WEIGHT_FUNC = function DEFAULT_WEIGHT_FUNC() {
+  return 1;
+};
+function floydWarshall(g, weightFn, edgeFn) {
+  return runFloydWarshall(g, weightFn || DEFAULT_WEIGHT_FUNC, edgeFn || function (v) {
+    return g.outEdges(v);
+  });
 }
-
 function runFloydWarshall(g, weightFn, edgeFn) {
   var results = {};
   var nodes = g.nodes();
-
-  nodes.forEach(function(v) {
+  nodes.forEach(function (v) {
     results[v] = {};
-    results[v][v] = { distance: 0 };
-    nodes.forEach(function(w) {
+    results[v][v] = {
+      distance: 0
+    };
+    nodes.forEach(function (w) {
       if (v !== w) {
-        results[v][w] = { distance: Number.POSITIVE_INFINITY };
+        results[v][w] = {
+          distance: Number.POSITIVE_INFINITY
+        };
       }
     });
-    edgeFn(v).forEach(function(edge) {
+    edgeFn(v).forEach(function (edge) {
       var w = edge.v === v ? edge.w : edge.v;
       var d = weightFn(edge);
-      results[v][w] = { distance: d, predecessor: v };
+      results[v][w] = {
+        distance: d,
+        predecessor: v
+      };
     });
   });
-
-  nodes.forEach(function(k) {
+  nodes.forEach(function (k) {
     var rowK = results[k];
-    nodes.forEach(function(i) {
+    nodes.forEach(function (i) {
       var rowI = results[i];
-      nodes.forEach(function(j) {
+      nodes.forEach(function (j) {
         var ik = rowI[k];
         var kj = rowK[j];
         var ij = rowI[j];
@@ -41,6 +52,5 @@ function runFloydWarshall(g, weightFn, edgeFn) {
       });
     });
   });
-
   return results;
 }

--- a/lib/alg/floyd-warshall.js
+++ b/lib/alg/floyd-warshall.js
@@ -3,10 +3,8 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = floydWarshall;
-var DEFAULT_WEIGHT_FUNC = function DEFAULT_WEIGHT_FUNC() {
-  return 1;
-};
+exports.default = floydWarshall;
+var DEFAULT_WEIGHT_FUNC = () => 1;
 function floydWarshall(g, weightFn, edgeFn) {
   return runFloydWarshall(g, weightFn || DEFAULT_WEIGHT_FUNC, edgeFn || function (v) {
     return g.outEdges(v);
@@ -54,3 +52,4 @@ function runFloydWarshall(g, weightFn, edgeFn) {
   });
   return results;
 }
+module.exports = exports.default;

--- a/lib/alg/index.js
+++ b/lib/alg/index.js
@@ -1,13 +1,11 @@
-module.exports = {
-  components: require("./components"),
-  dijkstra: require("./dijkstra"),
-  dijkstraAll: require("./dijkstra-all"),
-  findCycles: require("./find-cycles"),
-  floydWarshall: require("./floyd-warshall"),
-  isAcyclic: require("./is-acyclic"),
-  postorder: require("./postorder"),
-  preorder: require("./preorder"),
-  prim: require("./prim"),
-  tarjan: require("./tarjan"),
-  topsort: require("./topsort")
-};
+export { default as components } from "./components.js";
+export { default as dijkstra } from "./dijkstra.js";
+export { default as dijkstraAll } from "./dijkstra-all.js";
+export { default as findCycles } from "./find-cycles.js";
+export { default as floydWarshall } from "./floyd-warshall.js";
+export { default as isAcyclic } from "./is-acyclic.js";
+export { default as postorder } from "./postorder.js";
+export { default as preorder } from "./preorder.js";
+export { default as prim } from "./prim.js";
+export { default as tarjan } from "./tarjan.js";
+export { default as topsort } from "./topsort.js";

--- a/lib/alg/index.js
+++ b/lib/alg/index.js
@@ -1,11 +1,83 @@
-export { default as components } from "./components.js";
-export { default as dijkstra } from "./dijkstra.js";
-export { default as dijkstraAll } from "./dijkstra-all.js";
-export { default as findCycles } from "./find-cycles.js";
-export { default as floydWarshall } from "./floyd-warshall.js";
-export { default as isAcyclic } from "./is-acyclic.js";
-export { default as postorder } from "./postorder.js";
-export { default as preorder } from "./preorder.js";
-export { default as prim } from "./prim.js";
-export { default as tarjan } from "./tarjan.js";
-export { default as topsort } from "./topsort.js";
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "components", {
+  enumerable: true,
+  get: function get() {
+    return _components["default"];
+  }
+});
+Object.defineProperty(exports, "dijkstra", {
+  enumerable: true,
+  get: function get() {
+    return _dijkstra["default"];
+  }
+});
+Object.defineProperty(exports, "dijkstraAll", {
+  enumerable: true,
+  get: function get() {
+    return _dijkstraAll["default"];
+  }
+});
+Object.defineProperty(exports, "findCycles", {
+  enumerable: true,
+  get: function get() {
+    return _findCycles["default"];
+  }
+});
+Object.defineProperty(exports, "floydWarshall", {
+  enumerable: true,
+  get: function get() {
+    return _floydWarshall["default"];
+  }
+});
+Object.defineProperty(exports, "isAcyclic", {
+  enumerable: true,
+  get: function get() {
+    return _isAcyclic["default"];
+  }
+});
+Object.defineProperty(exports, "postorder", {
+  enumerable: true,
+  get: function get() {
+    return _postorder["default"];
+  }
+});
+Object.defineProperty(exports, "preorder", {
+  enumerable: true,
+  get: function get() {
+    return _preorder["default"];
+  }
+});
+Object.defineProperty(exports, "prim", {
+  enumerable: true,
+  get: function get() {
+    return _prim["default"];
+  }
+});
+Object.defineProperty(exports, "tarjan", {
+  enumerable: true,
+  get: function get() {
+    return _tarjan["default"];
+  }
+});
+Object.defineProperty(exports, "topsort", {
+  enumerable: true,
+  get: function get() {
+    return _topsort["default"];
+  }
+});
+var _components = _interopRequireDefault(require("./components.js"));
+var _dijkstra = _interopRequireDefault(require("./dijkstra.js"));
+var _dijkstraAll = _interopRequireDefault(require("./dijkstra-all.js"));
+var _findCycles = _interopRequireDefault(require("./find-cycles.js"));
+var _floydWarshall = _interopRequireDefault(require("./floyd-warshall.js"));
+var _isAcyclic = _interopRequireDefault(require("./is-acyclic.js"));
+var _postorder = _interopRequireDefault(require("./postorder.js"));
+var _preorder = _interopRequireDefault(require("./preorder.js"));
+var _prim = _interopRequireDefault(require("./prim.js"));
+var _tarjan = _interopRequireDefault(require("./tarjan.js"));
+var _topsort = _interopRequireDefault(require("./topsort.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }

--- a/lib/alg/index.js
+++ b/lib/alg/index.js
@@ -5,68 +5,68 @@ Object.defineProperty(exports, "__esModule", {
 });
 Object.defineProperty(exports, "components", {
   enumerable: true,
-  get: function get() {
-    return _components["default"];
+  get: function () {
+    return _components.default;
   }
 });
 Object.defineProperty(exports, "dijkstra", {
   enumerable: true,
-  get: function get() {
-    return _dijkstra["default"];
+  get: function () {
+    return _dijkstra.default;
   }
 });
 Object.defineProperty(exports, "dijkstraAll", {
   enumerable: true,
-  get: function get() {
-    return _dijkstraAll["default"];
+  get: function () {
+    return _dijkstraAll.default;
   }
 });
 Object.defineProperty(exports, "findCycles", {
   enumerable: true,
-  get: function get() {
-    return _findCycles["default"];
+  get: function () {
+    return _findCycles.default;
   }
 });
 Object.defineProperty(exports, "floydWarshall", {
   enumerable: true,
-  get: function get() {
-    return _floydWarshall["default"];
+  get: function () {
+    return _floydWarshall.default;
   }
 });
 Object.defineProperty(exports, "isAcyclic", {
   enumerable: true,
-  get: function get() {
-    return _isAcyclic["default"];
+  get: function () {
+    return _isAcyclic.default;
   }
 });
 Object.defineProperty(exports, "postorder", {
   enumerable: true,
-  get: function get() {
-    return _postorder["default"];
+  get: function () {
+    return _postorder.default;
   }
 });
 Object.defineProperty(exports, "preorder", {
   enumerable: true,
-  get: function get() {
-    return _preorder["default"];
+  get: function () {
+    return _preorder.default;
   }
 });
 Object.defineProperty(exports, "prim", {
   enumerable: true,
-  get: function get() {
-    return _prim["default"];
+  get: function () {
+    return _prim.default;
   }
 });
 Object.defineProperty(exports, "tarjan", {
   enumerable: true,
-  get: function get() {
-    return _tarjan["default"];
+  get: function () {
+    return _tarjan.default;
   }
 });
 Object.defineProperty(exports, "topsort", {
   enumerable: true,
-  get: function get() {
-    return _topsort["default"];
+  get: function () {
+    return _topsort.default;
   }
 });
 var _components = _interopRequireDefault(require("./components.js"));
@@ -80,4 +80,4 @@ var _preorder = _interopRequireDefault(require("./preorder.js"));
 var _prim = _interopRequireDefault(require("./prim.js"));
 var _tarjan = _interopRequireDefault(require("./tarjan.js"));
 var _topsort = _interopRequireDefault(require("./topsort.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/lib/alg/is-acyclic.js
+++ b/lib/alg/is-acyclic.js
@@ -1,8 +1,6 @@
-var topsort = require("./topsort");
+import default as topsort from "./topsort.js";
 
-module.exports = isAcyclic;
-
-function isAcyclic(g) {
+export default function isAcyclic(g) {
   try {
     topsort(g);
   } catch (e) {

--- a/lib/alg/is-acyclic.js
+++ b/lib/alg/is-acyclic.js
@@ -1,4 +1,4 @@
-import default as topsort from "./topsort.js";
+import { default as topsort } from "./topsort.js";
 
 export default function isAcyclic(g) {
   try {

--- a/lib/alg/is-acyclic.js
+++ b/lib/alg/is-acyclic.js
@@ -1,10 +1,16 @@
-import { default as topsort } from "./topsort.js";
+"use strict";
 
-export default function isAcyclic(g) {
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = isAcyclic;
+var _topsort = _interopRequireDefault(require("./topsort.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function isAcyclic(g) {
   try {
-    topsort(g);
+    (0, _topsort["default"])(g);
   } catch (e) {
-    if (e instanceof topsort.CycleException) {
+    if (e instanceof _topsort["default"].CycleException) {
       return false;
     }
     throw e;

--- a/lib/alg/is-acyclic.js
+++ b/lib/alg/is-acyclic.js
@@ -3,17 +3,18 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = isAcyclic;
+exports.default = isAcyclic;
 var _topsort = _interopRequireDefault(require("./topsort.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function isAcyclic(g) {
   try {
-    (0, _topsort["default"])(g);
+    (0, _topsort.default)(g);
   } catch (e) {
-    if (e instanceof _topsort["default"].CycleException) {
+    if (e instanceof _topsort.default.CycleException) {
       return false;
     }
     throw e;
   }
   return true;
 }
+module.exports = exports.default;

--- a/lib/alg/postorder.js
+++ b/lib/alg/postorder.js
@@ -3,9 +3,10 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = postorder;
+exports.default = postorder;
 var _dfs = _interopRequireDefault(require("./dfs.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function postorder(g, vs) {
-  return (0, _dfs["default"])(g, vs, "post");
+  return (0, _dfs.default)(g, vs, "post");
 }
+module.exports = exports.default;

--- a/lib/alg/postorder.js
+++ b/lib/alg/postorder.js
@@ -1,5 +1,11 @@
-import { default as dfs } from "./dfs.js";
+"use strict";
 
-export default function postorder(g, vs) {
-  return dfs(g, vs, "post");
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = postorder;
+var _dfs = _interopRequireDefault(require("./dfs.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function postorder(g, vs) {
+  return (0, _dfs["default"])(g, vs, "post");
 }

--- a/lib/alg/postorder.js
+++ b/lib/alg/postorder.js
@@ -1,7 +1,5 @@
-var dfs = require("./dfs");
+import default as dfs from "./dfs.js";
 
-module.exports = postorder;
-
-function postorder(g, vs) {
+export default function postorder(g, vs) {
   return dfs(g, vs, "post");
 }

--- a/lib/alg/postorder.js
+++ b/lib/alg/postorder.js
@@ -1,4 +1,4 @@
-import default as dfs from "./dfs.js";
+import { default as dfs } from "./dfs.js";
 
 export default function postorder(g, vs) {
   return dfs(g, vs, "post");

--- a/lib/alg/preorder.js
+++ b/lib/alg/preorder.js
@@ -1,7 +1,5 @@
-var dfs = require("./dfs");
+import default as dfs from "./dfs.js";
 
-module.exports = preorder;
-
-function preorder(g, vs) {
+export default function preorder(g, vs) {
   return dfs(g, vs, "pre");
 }

--- a/lib/alg/preorder.js
+++ b/lib/alg/preorder.js
@@ -1,4 +1,4 @@
-import default as dfs from "./dfs.js";
+import { default as dfs } from "./dfs.js";
 
 export default function preorder(g, vs) {
   return dfs(g, vs, "pre");

--- a/lib/alg/preorder.js
+++ b/lib/alg/preorder.js
@@ -1,5 +1,11 @@
-import { default as dfs } from "./dfs.js";
+"use strict";
 
-export default function preorder(g, vs) {
-  return dfs(g, vs, "pre");
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = preorder;
+var _dfs = _interopRequireDefault(require("./dfs.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function preorder(g, vs) {
+  return (0, _dfs["default"])(g, vs, "pre");
 }

--- a/lib/alg/preorder.js
+++ b/lib/alg/preorder.js
@@ -3,9 +3,10 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = preorder;
+exports.default = preorder;
 var _dfs = _interopRequireDefault(require("./dfs.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function preorder(g, vs) {
-  return (0, _dfs["default"])(g, vs, "pre");
+  return (0, _dfs.default)(g, vs, "pre");
 }
+module.exports = exports.default;

--- a/lib/alg/prim.js
+++ b/lib/alg/prim.js
@@ -3,14 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = prim;
+exports.default = prim;
 var _graph = _interopRequireDefault(require("../graph.js"));
 var _priorityQueue = _interopRequireDefault(require("../data/priority-queue.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 function prim(g, weightFunc) {
-  var result = new _graph["default"]();
+  var result = new _graph.default();
   var parents = {};
-  var pq = new _priorityQueue["default"]();
+  var pq = new _priorityQueue.default();
   var v;
   function updateNeighbors(edge) {
     var w = edge.v === v ? edge.w : edge.v;
@@ -47,3 +47,4 @@ function prim(g, weightFunc) {
   }
   return result;
 }
+module.exports = exports.default;

--- a/lib/alg/prim.js
+++ b/lib/alg/prim.js
@@ -1,9 +1,7 @@
-var Graph = require("../graph");
-var PriorityQueue = require("../data/priority-queue");
+import default as Graph from "../graph.js";
+import default as PriorityQueue from "../data/priority-queue.js";
 
-module.exports = prim;
-
-function prim(g, weightFunc) {
+export default function prim(g, weightFunc) {
   var result = new Graph();
   var parents = {};
   var pq = new PriorityQueue();

--- a/lib/alg/prim.js
+++ b/lib/alg/prim.js
@@ -1,5 +1,5 @@
-import default as Graph from "../graph.js";
-import default as PriorityQueue from "../data/priority-queue.js";
+import { default as Graph } from "../graph.js";
+import { default as PriorityQueue } from "../data/priority-queue.js";
 
 export default function prim(g, weightFunc) {
   var result = new Graph();

--- a/lib/alg/tarjan.js
+++ b/lib/alg/tarjan.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = tarjan;
+exports.default = tarjan;
 function tarjan(g) {
   var index = 0;
   var stack = [];
@@ -42,3 +42,4 @@ function tarjan(g) {
   });
   return results;
 }
+module.exports = exports.default;

--- a/lib/alg/tarjan.js
+++ b/lib/alg/tarjan.js
@@ -1,6 +1,4 @@
-module.exports = tarjan;
-
-function tarjan(g) {
+export default function tarjan(g) {
   var index = 0;
   var stack = [];
   var visited = {}; // node id -> { onStack, lowlink, index }

--- a/lib/alg/topsort.js
+++ b/lib/alg/topsort.js
@@ -1,13 +1,33 @@
-export default function topsort(g) {
+"use strict";
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = topsort;
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _callSuper(t, o, e) { return o = _getPrototypeOf(o), _possibleConstructorReturn(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], _getPrototypeOf(t).constructor) : o.apply(t, e)); }
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+function _construct(t, e, r) { if (_isNativeReflectConstruct()) return Reflect.construct.apply(null, arguments); var o = [null]; o.push.apply(o, e); var p = new (t.bind.apply(t, o))(); return r && _setPrototypeOf(p, r.prototype), p; }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); }
+function _isNativeFunction(fn) { try { return Function.toString.call(fn).indexOf("[native code]") !== -1; } catch (e) { return typeof fn === "function"; } }
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function topsort(g) {
   var visited = {};
   var stack = {};
   var results = [];
-
   function visit(node) {
     if (stack.hasOwnProperty(node)) {
       throw new CycleException();
     }
-
     if (!visited.hasOwnProperty(node)) {
       stack[node] = true;
       visited[node] = true;
@@ -16,20 +36,18 @@ export default function topsort(g) {
       results.push(node);
     }
   }
-
   g.sinks().forEach(visit);
-
   if (Object.keys(visited).length !== g.nodeCount()) {
     throw new CycleException();
   }
-
   return results;
 }
-
-class CycleException extends Error {
-  constructor() {
-    super(...arguments);
+var CycleException = /*#__PURE__*/function (_Error) {
+  _inherits(CycleException, _Error);
+  function CycleException() {
+    _classCallCheck(this, CycleException);
+    return _callSuper(this, CycleException, arguments);
   }
-}
-
+  return _createClass(CycleException);
+}( /*#__PURE__*/_wrapNativeSuper(Error));
 topsort.CycleException = CycleException;

--- a/lib/alg/topsort.js
+++ b/lib/alg/topsort.js
@@ -1,4 +1,4 @@
-function topsort(g) {
+export default function topsort(g) {
   var visited = {};
   var stack = {};
   var results = [];
@@ -32,5 +32,4 @@ class CycleException extends Error {
   }
 }
 
-module.exports = topsort;
 topsort.CycleException = CycleException;

--- a/lib/alg/topsort.js
+++ b/lib/alg/topsort.js
@@ -1,25 +1,9 @@
 "use strict";
 
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = topsort;
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-function _callSuper(t, o, e) { return o = _getPrototypeOf(o), _possibleConstructorReturn(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], _getPrototypeOf(t).constructor) : o.apply(t, e)); }
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
-function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
-function _construct(t, e, r) { if (_isNativeReflectConstruct()) return Reflect.construct.apply(null, arguments); var o = [null]; o.push.apply(o, e); var p = new (t.bind.apply(t, o))(); return r && _setPrototypeOf(p, r.prototype), p; }
-function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); }
-function _isNativeFunction(fn) { try { return Function.toString.call(fn).indexOf("[native code]") !== -1; } catch (e) { return typeof fn === "function"; } }
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+exports.default = topsort;
 function topsort(g) {
   var visited = {};
   var stack = {};
@@ -42,12 +26,10 @@ function topsort(g) {
   }
   return results;
 }
-var CycleException = /*#__PURE__*/function (_Error) {
-  _inherits(CycleException, _Error);
-  function CycleException() {
-    _classCallCheck(this, CycleException);
-    return _callSuper(this, CycleException, arguments);
+class CycleException extends Error {
+  constructor() {
+    super(...arguments);
   }
-  return _createClass(CycleException);
-}( /*#__PURE__*/_wrapNativeSuper(Error));
+}
 topsort.CycleException = CycleException;
+module.exports = exports.default;

--- a/lib/data/priority-queue.js
+++ b/lib/data/priority-queue.js
@@ -1,27 +1,9 @@
 "use strict";
 
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-function _classPrivateMethodInitSpec(obj, privateSet) { _checkPrivateRedeclaration(obj, privateSet); privateSet.add(obj); }
-function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
-function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
-function _classPrivateMethodGet(receiver, privateSet, fn) { if (!privateSet.has(receiver)) { throw new TypeError("attempted to get private field on non-instance"); } return fn; }
-function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
-function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
-function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
-var _arr = /*#__PURE__*/new WeakMap();
-var _keyIndices = /*#__PURE__*/new WeakMap();
-var _heapify = /*#__PURE__*/new WeakSet();
-var _decrease = /*#__PURE__*/new WeakSet();
-var _swap = /*#__PURE__*/new WeakSet();
+exports.default = void 0;
 /**
  * A min-priority queue data structure. This algorithm is derived from Cormen,
  * et al., "Introduction to Algorithms". The basic idea of a min-priority
@@ -29,175 +11,147 @@ var _swap = /*#__PURE__*/new WeakSet();
  * the queue. Adding and removing elements takes O(log n) time. A key can
  * have its priority decreased in O(log n) time.
  */
-var PriorityQueue = exports["default"] = /*#__PURE__*/function () {
-  function PriorityQueue() {
-    _classCallCheck(this, PriorityQueue);
-    _classPrivateMethodInitSpec(this, _swap);
-    _classPrivateMethodInitSpec(this, _decrease);
-    _classPrivateMethodInitSpec(this, _heapify);
-    _classPrivateFieldInitSpec(this, _arr, {
-      writable: true,
-      value: []
-    });
-    _classPrivateFieldInitSpec(this, _keyIndices, {
-      writable: true,
-      value: {}
+class PriorityQueue {
+  #arr = [];
+  #keyIndices = {};
+
+  /**
+   * Returns the number of elements in the queue. Takes `O(1)` time.
+   */
+  size() {
+    return this.#arr.length;
+  }
+
+  /**
+   * Returns the keys that are in the queue. Takes `O(n)` time.
+   */
+  keys() {
+    return this.#arr.map(function (x) {
+      return x.key;
     });
   }
-  _createClass(PriorityQueue, [{
-    key: "size",
-    value:
-    /**
-     * Returns the number of elements in the queue. Takes `O(1)` time.
-     */
-    function size() {
-      return _classPrivateFieldGet(this, _arr).length;
-    }
 
-    /**
-     * Returns the keys that are in the queue. Takes `O(n)` time.
-     */
-  }, {
-    key: "keys",
-    value: function keys() {
-      return _classPrivateFieldGet(this, _arr).map(function (x) {
-        return x.key;
+  /**
+   * Returns `true` if **key** is in the queue and `false` if not.
+   */
+  has(key) {
+    return this.#keyIndices.hasOwnProperty(key);
+  }
+
+  /**
+   * Returns the priority for **key**. If **key** is not present in the queue
+   * then this function returns `undefined`. Takes `O(1)` time.
+   *
+   * @param {Object} key
+   */
+  priority(key) {
+    var index = this.#keyIndices[key];
+    if (index !== undefined) {
+      return this.#arr[index].priority;
+    }
+  }
+
+  /**
+   * Returns the key for the minimum element in this queue. If the queue is
+   * empty this function throws an Error. Takes `O(1)` time.
+   */
+  min() {
+    if (this.size() === 0) {
+      throw new Error("Queue underflow");
+    }
+    return this.#arr[0].key;
+  }
+
+  /**
+   * Inserts a new key into the priority queue. If the key already exists in
+   * the queue this function returns `false`; otherwise it will return `true`.
+   * Takes `O(n)` time.
+   *
+   * @param {Object} key the key to add
+   * @param {Number} priority the initial priority for the key
+   */
+  add(key, priority) {
+    var keyIndices = this.#keyIndices;
+    key = String(key);
+    if (!keyIndices.hasOwnProperty(key)) {
+      var arr = this.#arr;
+      var index = arr.length;
+      keyIndices[key] = index;
+      arr.push({
+        key: key,
+        priority: priority
       });
+      this.#decrease(index);
+      return true;
     }
+    return false;
+  }
 
-    /**
-     * Returns `true` if **key** is in the queue and `false` if not.
-     */
-  }, {
-    key: "has",
-    value: function has(key) {
-      return _classPrivateFieldGet(this, _keyIndices).hasOwnProperty(key);
+  /**
+   * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
+   */
+  removeMin() {
+    this.#swap(0, this.#arr.length - 1);
+    var min = this.#arr.pop();
+    delete this.#keyIndices[min.key];
+    this.#heapify(0);
+    return min.key;
+  }
+
+  /**
+   * Decreases the priority for **key** to **priority**. If the new priority is
+   * greater than the previous priority, this function will throw an Error.
+   *
+   * @param {Object} key the key for which to raise priority
+   * @param {Number} priority the new priority for the key
+   */
+  decrease(key, priority) {
+    var index = this.#keyIndices[key];
+    if (priority > this.#arr[index].priority) {
+      throw new Error("New priority is greater than current priority. " + "Key: " + key + " Old: " + this.#arr[index].priority + " New: " + priority);
     }
-
-    /**
-     * Returns the priority for **key**. If **key** is not present in the queue
-     * then this function returns `undefined`. Takes `O(1)` time.
-     *
-     * @param {Object} key
-     */
-  }, {
-    key: "priority",
-    value: function priority(key) {
-      var index = _classPrivateFieldGet(this, _keyIndices)[key];
-      if (index !== undefined) {
-        return _classPrivateFieldGet(this, _arr)[index].priority;
+    this.#arr[index].priority = priority;
+    this.#decrease(index);
+  }
+  #heapify(i) {
+    var arr = this.#arr;
+    var l = 2 * i;
+    var r = l + 1;
+    var largest = i;
+    if (l < arr.length) {
+      largest = arr[l].priority < arr[largest].priority ? l : largest;
+      if (r < arr.length) {
+        largest = arr[r].priority < arr[largest].priority ? r : largest;
       }
-    }
-
-    /**
-     * Returns the key for the minimum element in this queue. If the queue is
-     * empty this function throws an Error. Takes `O(1)` time.
-     */
-  }, {
-    key: "min",
-    value: function min() {
-      if (this.size() === 0) {
-        throw new Error("Queue underflow");
+      if (largest !== i) {
+        this.#swap(i, largest);
+        this.#heapify(largest);
       }
-      return _classPrivateFieldGet(this, _arr)[0].key;
-    }
-
-    /**
-     * Inserts a new key into the priority queue. If the key already exists in
-     * the queue this function returns `false`; otherwise it will return `true`.
-     * Takes `O(n)` time.
-     *
-     * @param {Object} key the key to add
-     * @param {Number} priority the initial priority for the key
-     */
-  }, {
-    key: "add",
-    value: function add(key, priority) {
-      var keyIndices = _classPrivateFieldGet(this, _keyIndices);
-      key = String(key);
-      if (!keyIndices.hasOwnProperty(key)) {
-        var arr = _classPrivateFieldGet(this, _arr);
-        var index = arr.length;
-        keyIndices[key] = index;
-        arr.push({
-          key: key,
-          priority: priority
-        });
-        _classPrivateMethodGet(this, _decrease, _decrease2).call(this, index);
-        return true;
-      }
-      return false;
-    }
-
-    /**
-     * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
-     */
-  }, {
-    key: "removeMin",
-    value: function removeMin() {
-      _classPrivateMethodGet(this, _swap, _swap2).call(this, 0, _classPrivateFieldGet(this, _arr).length - 1);
-      var min = _classPrivateFieldGet(this, _arr).pop();
-      delete _classPrivateFieldGet(this, _keyIndices)[min.key];
-      _classPrivateMethodGet(this, _heapify, _heapify2).call(this, 0);
-      return min.key;
-    }
-
-    /**
-     * Decreases the priority for **key** to **priority**. If the new priority is
-     * greater than the previous priority, this function will throw an Error.
-     *
-     * @param {Object} key the key for which to raise priority
-     * @param {Number} priority the new priority for the key
-     */
-  }, {
-    key: "decrease",
-    value: function decrease(key, priority) {
-      var index = _classPrivateFieldGet(this, _keyIndices)[key];
-      if (priority > _classPrivateFieldGet(this, _arr)[index].priority) {
-        throw new Error("New priority is greater than current priority. " + "Key: " + key + " Old: " + _classPrivateFieldGet(this, _arr)[index].priority + " New: " + priority);
-      }
-      _classPrivateFieldGet(this, _arr)[index].priority = priority;
-      _classPrivateMethodGet(this, _decrease, _decrease2).call(this, index);
-    }
-  }]);
-  return PriorityQueue;
-}();
-function _heapify2(i) {
-  var arr = _classPrivateFieldGet(this, _arr);
-  var l = 2 * i;
-  var r = l + 1;
-  var largest = i;
-  if (l < arr.length) {
-    largest = arr[l].priority < arr[largest].priority ? l : largest;
-    if (r < arr.length) {
-      largest = arr[r].priority < arr[largest].priority ? r : largest;
-    }
-    if (largest !== i) {
-      _classPrivateMethodGet(this, _swap, _swap2).call(this, i, largest);
-      _classPrivateMethodGet(this, _heapify, _heapify2).call(this, largest);
     }
   }
-}
-function _decrease2(index) {
-  var arr = _classPrivateFieldGet(this, _arr);
-  var priority = arr[index].priority;
-  var parent;
-  while (index !== 0) {
-    parent = index >> 1;
-    if (arr[parent].priority < priority) {
-      break;
+  #decrease(index) {
+    var arr = this.#arr;
+    var priority = arr[index].priority;
+    var parent;
+    while (index !== 0) {
+      parent = index >> 1;
+      if (arr[parent].priority < priority) {
+        break;
+      }
+      this.#swap(index, parent);
+      index = parent;
     }
-    _classPrivateMethodGet(this, _swap, _swap2).call(this, index, parent);
-    index = parent;
+  }
+  #swap(i, j) {
+    var arr = this.#arr;
+    var keyIndices = this.#keyIndices;
+    var origArrI = arr[i];
+    var origArrJ = arr[j];
+    arr[i] = origArrJ;
+    arr[j] = origArrI;
+    keyIndices[origArrJ.key] = i;
+    keyIndices[origArrI.key] = j;
   }
 }
-function _swap2(i, j) {
-  var arr = _classPrivateFieldGet(this, _arr);
-  var keyIndices = _classPrivateFieldGet(this, _keyIndices);
-  var origArrI = arr[i];
-  var origArrJ = arr[j];
-  arr[i] = origArrJ;
-  arr[j] = origArrI;
-  keyIndices[origArrJ.key] = i;
-  keyIndices[origArrI.key] = j;
-}
+exports.default = PriorityQueue;
+module.exports = exports.default;

--- a/lib/data/priority-queue.js
+++ b/lib/data/priority-queue.js
@@ -1,3 +1,27 @@
+"use strict";
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _classPrivateMethodInitSpec(obj, privateSet) { _checkPrivateRedeclaration(obj, privateSet); privateSet.add(obj); }
+function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+function _classPrivateMethodGet(receiver, privateSet, fn) { if (!privateSet.has(receiver)) { throw new TypeError("attempted to get private field on non-instance"); } return fn; }
+function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
+function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
+function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+var _arr = /*#__PURE__*/new WeakMap();
+var _keyIndices = /*#__PURE__*/new WeakMap();
+var _heapify = /*#__PURE__*/new WeakSet();
+var _decrease = /*#__PURE__*/new WeakSet();
+var _swap = /*#__PURE__*/new WeakSet();
 /**
  * A min-priority queue data structure. This algorithm is derived from Cormen,
  * et al., "Introduction to Algorithms". The basic idea of a min-priority
@@ -5,144 +29,175 @@
  * the queue. Adding and removing elements takes O(log n) time. A key can
  * have its priority decreased in O(log n) time.
  */
-export default class PriorityQueue {
-  #arr = [];
-  #keyIndices = {};
-
-  /**
-   * Returns the number of elements in the queue. Takes `O(1)` time.
-   */
-  size() {
-    return this.#arr.length;
+var PriorityQueue = exports["default"] = /*#__PURE__*/function () {
+  function PriorityQueue() {
+    _classCallCheck(this, PriorityQueue);
+    _classPrivateMethodInitSpec(this, _swap);
+    _classPrivateMethodInitSpec(this, _decrease);
+    _classPrivateMethodInitSpec(this, _heapify);
+    _classPrivateFieldInitSpec(this, _arr, {
+      writable: true,
+      value: []
+    });
+    _classPrivateFieldInitSpec(this, _keyIndices, {
+      writable: true,
+      value: {}
+    });
   }
-
-  /**
-   * Returns the keys that are in the queue. Takes `O(n)` time.
-   */
-  keys() {
-    return this.#arr.map(function(x) { return x.key; });
-  }
-
-  /**
-   * Returns `true` if **key** is in the queue and `false` if not.
-   */
-  has(key) {
-    return this.#keyIndices.hasOwnProperty(key);
-  }
-
-  /**
-   * Returns the priority for **key**. If **key** is not present in the queue
-   * then this function returns `undefined`. Takes `O(1)` time.
-   *
-   * @param {Object} key
-   */
-  priority(key) {
-    var index = this.#keyIndices[key];
-    if (index !== undefined) {
-      return this.#arr[index].priority;
+  _createClass(PriorityQueue, [{
+    key: "size",
+    value:
+    /**
+     * Returns the number of elements in the queue. Takes `O(1)` time.
+     */
+    function size() {
+      return _classPrivateFieldGet(this, _arr).length;
     }
-  }
 
-  /**
-   * Returns the key for the minimum element in this queue. If the queue is
-   * empty this function throws an Error. Takes `O(1)` time.
-   */
-  min() {
-    if (this.size() === 0) {
-      throw new Error("Queue underflow");
+    /**
+     * Returns the keys that are in the queue. Takes `O(n)` time.
+     */
+  }, {
+    key: "keys",
+    value: function keys() {
+      return _classPrivateFieldGet(this, _arr).map(function (x) {
+        return x.key;
+      });
     }
-    return this.#arr[0].key;
-  }
 
-  /**
-   * Inserts a new key into the priority queue. If the key already exists in
-   * the queue this function returns `false`; otherwise it will return `true`.
-   * Takes `O(n)` time.
-   *
-   * @param {Object} key the key to add
-   * @param {Number} priority the initial priority for the key
-   */
-  add(key, priority) {
-    var keyIndices = this.#keyIndices;
-    key = String(key);
-    if (!keyIndices.hasOwnProperty(key)) {
-      var arr = this.#arr;
-      var index = arr.length;
-      keyIndices[key] = index;
-      arr.push({key: key, priority: priority});
-      this.#decrease(index);
-      return true;
+    /**
+     * Returns `true` if **key** is in the queue and `false` if not.
+     */
+  }, {
+    key: "has",
+    value: function has(key) {
+      return _classPrivateFieldGet(this, _keyIndices).hasOwnProperty(key);
     }
-    return false;
-  }
 
-  /**
-   * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
-   */
-  removeMin() {
-    this.#swap(0, this.#arr.length - 1);
-    var min = this.#arr.pop();
-    delete this.#keyIndices[min.key];
-    this.#heapify(0);
-    return min.key;
-  }
-
-  /**
-   * Decreases the priority for **key** to **priority**. If the new priority is
-   * greater than the previous priority, this function will throw an Error.
-   *
-   * @param {Object} key the key for which to raise priority
-   * @param {Number} priority the new priority for the key
-   */
-  decrease(key, priority) {
-    var index = this.#keyIndices[key];
-    if (priority > this.#arr[index].priority) {
-      throw new Error("New priority is greater than current priority. " +
-          "Key: " + key + " Old: " + this.#arr[index].priority + " New: " + priority);
-    }
-    this.#arr[index].priority = priority;
-    this.#decrease(index);
-  }
-
-  #heapify(i) {
-    var arr = this.#arr;
-    var l = 2 * i;
-    var r = l + 1;
-    var largest = i;
-    if (l < arr.length) {
-      largest = arr[l].priority < arr[largest].priority ? l : largest;
-      if (r < arr.length) {
-        largest = arr[r].priority < arr[largest].priority ? r : largest;
-      }
-      if (largest !== i) {
-        this.#swap(i, largest);
-        this.#heapify(largest);
+    /**
+     * Returns the priority for **key**. If **key** is not present in the queue
+     * then this function returns `undefined`. Takes `O(1)` time.
+     *
+     * @param {Object} key
+     */
+  }, {
+    key: "priority",
+    value: function priority(key) {
+      var index = _classPrivateFieldGet(this, _keyIndices)[key];
+      if (index !== undefined) {
+        return _classPrivateFieldGet(this, _arr)[index].priority;
       }
     }
-  }
 
-  #decrease(index) {
-    var arr = this.#arr;
-    var priority = arr[index].priority;
-    var parent;
-    while (index !== 0) {
-      parent = index >> 1;
-      if (arr[parent].priority < priority) {
-        break;
+    /**
+     * Returns the key for the minimum element in this queue. If the queue is
+     * empty this function throws an Error. Takes `O(1)` time.
+     */
+  }, {
+    key: "min",
+    value: function min() {
+      if (this.size() === 0) {
+        throw new Error("Queue underflow");
       }
-      this.#swap(index, parent);
-      index = parent;
+      return _classPrivateFieldGet(this, _arr)[0].key;
+    }
+
+    /**
+     * Inserts a new key into the priority queue. If the key already exists in
+     * the queue this function returns `false`; otherwise it will return `true`.
+     * Takes `O(n)` time.
+     *
+     * @param {Object} key the key to add
+     * @param {Number} priority the initial priority for the key
+     */
+  }, {
+    key: "add",
+    value: function add(key, priority) {
+      var keyIndices = _classPrivateFieldGet(this, _keyIndices);
+      key = String(key);
+      if (!keyIndices.hasOwnProperty(key)) {
+        var arr = _classPrivateFieldGet(this, _arr);
+        var index = arr.length;
+        keyIndices[key] = index;
+        arr.push({
+          key: key,
+          priority: priority
+        });
+        _classPrivateMethodGet(this, _decrease, _decrease2).call(this, index);
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
+     */
+  }, {
+    key: "removeMin",
+    value: function removeMin() {
+      _classPrivateMethodGet(this, _swap, _swap2).call(this, 0, _classPrivateFieldGet(this, _arr).length - 1);
+      var min = _classPrivateFieldGet(this, _arr).pop();
+      delete _classPrivateFieldGet(this, _keyIndices)[min.key];
+      _classPrivateMethodGet(this, _heapify, _heapify2).call(this, 0);
+      return min.key;
+    }
+
+    /**
+     * Decreases the priority for **key** to **priority**. If the new priority is
+     * greater than the previous priority, this function will throw an Error.
+     *
+     * @param {Object} key the key for which to raise priority
+     * @param {Number} priority the new priority for the key
+     */
+  }, {
+    key: "decrease",
+    value: function decrease(key, priority) {
+      var index = _classPrivateFieldGet(this, _keyIndices)[key];
+      if (priority > _classPrivateFieldGet(this, _arr)[index].priority) {
+        throw new Error("New priority is greater than current priority. " + "Key: " + key + " Old: " + _classPrivateFieldGet(this, _arr)[index].priority + " New: " + priority);
+      }
+      _classPrivateFieldGet(this, _arr)[index].priority = priority;
+      _classPrivateMethodGet(this, _decrease, _decrease2).call(this, index);
+    }
+  }]);
+  return PriorityQueue;
+}();
+function _heapify2(i) {
+  var arr = _classPrivateFieldGet(this, _arr);
+  var l = 2 * i;
+  var r = l + 1;
+  var largest = i;
+  if (l < arr.length) {
+    largest = arr[l].priority < arr[largest].priority ? l : largest;
+    if (r < arr.length) {
+      largest = arr[r].priority < arr[largest].priority ? r : largest;
+    }
+    if (largest !== i) {
+      _classPrivateMethodGet(this, _swap, _swap2).call(this, i, largest);
+      _classPrivateMethodGet(this, _heapify, _heapify2).call(this, largest);
     }
   }
-
-  #swap(i, j) {
-    var arr = this.#arr;
-    var keyIndices = this.#keyIndices;
-    var origArrI = arr[i];
-    var origArrJ = arr[j];
-    arr[i] = origArrJ;
-    arr[j] = origArrI;
-    keyIndices[origArrJ.key] = i;
-    keyIndices[origArrI.key] = j;
+}
+function _decrease2(index) {
+  var arr = _classPrivateFieldGet(this, _arr);
+  var priority = arr[index].priority;
+  var parent;
+  while (index !== 0) {
+    parent = index >> 1;
+    if (arr[parent].priority < priority) {
+      break;
+    }
+    _classPrivateMethodGet(this, _swap, _swap2).call(this, index, parent);
+    index = parent;
   }
+}
+function _swap2(i, j) {
+  var arr = _classPrivateFieldGet(this, _arr);
+  var keyIndices = _classPrivateFieldGet(this, _keyIndices);
+  var origArrI = arr[i];
+  var origArrJ = arr[j];
+  arr[i] = origArrJ;
+  arr[j] = origArrI;
+  keyIndices[origArrJ.key] = i;
+  keyIndices[origArrI.key] = j;
 }

--- a/lib/data/priority-queue.js
+++ b/lib/data/priority-queue.js
@@ -5,7 +5,7 @@
  * the queue. Adding and removing elements takes O(log n) time. A key can
  * have its priority decreased in O(log n) time.
  */
-class PriorityQueue {
+export default class PriorityQueue {
   #arr = [];
   #keyIndices = {};
 
@@ -146,5 +146,3 @@ class PriorityQueue {
     keyIndices[origArrI.key] = j;
   }
 }
-
-module.exports = PriorityQueue;

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -14,7 +14,7 @@ var EDGE_KEY_DELIM = "\x01";
 //    edges up and, object properties, which have string keys, are the closest
 //    we're going to get to a performant hashtable in JavaScript.
 
-class Graph {
+export default class Graph {
   #isDirected = true;
   #isMultigraph = false;
   #isCompound = false;
@@ -692,5 +692,3 @@ function edgeArgsToObj(isDirected, v_, w_, name) {
 function edgeObjToId(isDirected, edgeObj) {
   return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
 }
-
-module.exports = Graph;

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -1,5 +1,31 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _classPrivateMethodInitSpec(obj, privateSet) { _checkPrivateRedeclaration(obj, privateSet); privateSet.add(obj); }
+function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+function _classPrivateMethodGet(receiver, privateSet, fn) { if (!privateSet.has(receiver)) { throw new TypeError("attempted to get private field on non-instance"); } return fn; }
+function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
+function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"); _classApplyDescriptorSet(receiver, descriptor, value); return value; }
+function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
+function _classApplyDescriptorSet(receiver, descriptor, value) { if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } }
 var DEFAULT_EDGE_NAME = "\x00";
 var GRAPH_NODE = "\x00";
 var EDGE_KEY_DELIM = "\x01";
@@ -13,66 +39,124 @@ var EDGE_KEY_DELIM = "\x01";
 //    reference edges. This is because we need a performant way to look these
 //    edges up and, object properties, which have string keys, are the closest
 //    we're going to get to a performant hashtable in JavaScript.
-
-export default class Graph {
-  #isDirected = true;
-  #isMultigraph = false;
-  #isCompound = false;
-
-  // Label for the graph itself
-  #label;
-
-  // Defaults to be set when creating a new node
-  #defaultNodeLabelFn = () => undefined;
-
-  // Defaults to be set when creating a new edge
-  #defaultEdgeLabelFn = () => undefined;
-
-  // v -> label
-  #nodes = {};
-
-  // v -> edgeObj
-  #in = {};
-
-  // u -> v -> Number
-  #preds = {};
-
-  // v -> edgeObj
-  #out = {};
-
-  // v -> w -> Number
-  #sucs = {};
-
-  // e -> edgeObj
-  #edgeObjs = {};
-
-  // e -> label
-  #edgeLabels = {};
-
-  /* Number of nodes in the graph. Should only be changed by the implementation. */
-  #nodeCount = 0;
-
-  /* Number of edges in the graph. Should only be changed by the implementation. */
-  #edgeCount = 0;
-
-  #parent;
-
-  #children;
-
-  constructor(opts) {
+var _isDirected = /*#__PURE__*/new WeakMap();
+var _isMultigraph = /*#__PURE__*/new WeakMap();
+var _isCompound = /*#__PURE__*/new WeakMap();
+var _label = /*#__PURE__*/new WeakMap();
+var _defaultNodeLabelFn = /*#__PURE__*/new WeakMap();
+var _defaultEdgeLabelFn = /*#__PURE__*/new WeakMap();
+var _nodes = /*#__PURE__*/new WeakMap();
+var _in = /*#__PURE__*/new WeakMap();
+var _preds = /*#__PURE__*/new WeakMap();
+var _out = /*#__PURE__*/new WeakMap();
+var _sucs = /*#__PURE__*/new WeakMap();
+var _edgeObjs = /*#__PURE__*/new WeakMap();
+var _edgeLabels = /*#__PURE__*/new WeakMap();
+var _nodeCount = /*#__PURE__*/new WeakMap();
+var _edgeCount = /*#__PURE__*/new WeakMap();
+var _parent = /*#__PURE__*/new WeakMap();
+var _children = /*#__PURE__*/new WeakMap();
+var _removeFromParentsChildList = /*#__PURE__*/new WeakSet();
+var Graph = exports["default"] = /*#__PURE__*/function () {
+  function Graph(opts) {
+    _classCallCheck(this, Graph);
+    _classPrivateMethodInitSpec(this, _removeFromParentsChildList);
+    _classPrivateFieldInitSpec(this, _isDirected, {
+      writable: true,
+      value: true
+    });
+    _classPrivateFieldInitSpec(this, _isMultigraph, {
+      writable: true,
+      value: false
+    });
+    _classPrivateFieldInitSpec(this, _isCompound, {
+      writable: true,
+      value: false
+    });
+    // Label for the graph itself
+    _classPrivateFieldInitSpec(this, _label, {
+      writable: true,
+      value: void 0
+    });
+    // Defaults to be set when creating a new node
+    _classPrivateFieldInitSpec(this, _defaultNodeLabelFn, {
+      writable: true,
+      value: function value() {
+        return undefined;
+      }
+    });
+    // Defaults to be set when creating a new edge
+    _classPrivateFieldInitSpec(this, _defaultEdgeLabelFn, {
+      writable: true,
+      value: function value() {
+        return undefined;
+      }
+    });
+    // v -> label
+    _classPrivateFieldInitSpec(this, _nodes, {
+      writable: true,
+      value: {}
+    });
+    // v -> edgeObj
+    _classPrivateFieldInitSpec(this, _in, {
+      writable: true,
+      value: {}
+    });
+    // u -> v -> Number
+    _classPrivateFieldInitSpec(this, _preds, {
+      writable: true,
+      value: {}
+    });
+    // v -> edgeObj
+    _classPrivateFieldInitSpec(this, _out, {
+      writable: true,
+      value: {}
+    });
+    // v -> w -> Number
+    _classPrivateFieldInitSpec(this, _sucs, {
+      writable: true,
+      value: {}
+    });
+    // e -> edgeObj
+    _classPrivateFieldInitSpec(this, _edgeObjs, {
+      writable: true,
+      value: {}
+    });
+    // e -> label
+    _classPrivateFieldInitSpec(this, _edgeLabels, {
+      writable: true,
+      value: {}
+    });
+    /* Number of nodes in the graph. Should only be changed by the implementation. */
+    _classPrivateFieldInitSpec(this, _nodeCount, {
+      writable: true,
+      value: 0
+    });
+    /* Number of edges in the graph. Should only be changed by the implementation. */
+    _classPrivateFieldInitSpec(this, _edgeCount, {
+      writable: true,
+      value: 0
+    });
+    _classPrivateFieldInitSpec(this, _parent, {
+      writable: true,
+      value: void 0
+    });
+    _classPrivateFieldInitSpec(this, _children, {
+      writable: true,
+      value: void 0
+    });
     if (opts) {
-      this.#isDirected = opts.hasOwnProperty("directed") ? opts.directed : true;
-      this.#isMultigraph = opts.hasOwnProperty("multigraph") ? opts.multigraph : false;
-      this.#isCompound = opts.hasOwnProperty("compound") ? opts.compound : false;
+      _classPrivateFieldSet(this, _isDirected, opts.hasOwnProperty("directed") ? opts.directed : true);
+      _classPrivateFieldSet(this, _isMultigraph, opts.hasOwnProperty("multigraph") ? opts.multigraph : false);
+      _classPrivateFieldSet(this, _isCompound, opts.hasOwnProperty("compound") ? opts.compound : false);
     }
-
-    if (this.#isCompound) {
+    if (_classPrivateFieldGet(this, _isCompound)) {
       // v -> parent
-      this.#parent = {};
+      _classPrivateFieldSet(this, _parent, {});
 
       // v -> children
-      this.#children = {};
-      this.#children[GRAPH_NODE] = {};
+      _classPrivateFieldSet(this, _children, {});
+      _classPrivateFieldGet(this, _children)[GRAPH_NODE] = {};
     }
   }
 
@@ -81,575 +165,650 @@ export default class Graph {
   /**
    * Whether graph was created with 'directed' flag set to true or not.
    */
-  isDirected() {
-    return this.#isDirected;
-  }
-
-  /**
-   * Whether graph was created with 'multigraph' flag set to true or not.
-   */
-  isMultigraph() {
-    return this.#isMultigraph;
-  }
-
-  /**
-   * Whether graph was created with 'compound' flag set to true or not.
-   */
-  isCompound() {
-    return this.#isCompound;
-  }
-
-  /**
-   * Sets the label of the graph.
-   */
-  setGraph(label) {
-    this.#label = label;
-    return this;
-  }
-
-  /**
-   * Gets the graph label.
-   */
-  graph() {
-    return this.#label;
-  }
-
-
-  /* === Node functions ========== */
-
-  /**
-   * Sets the default node label. If newDefault is a function, it will be
-   * invoked ach time when setting a label for a node. Otherwise, this label
-   * will be assigned as default label in case if no label was specified while
-   * setting a node.
-   * Complexity: O(1).
-   */
-  setDefaultNodeLabel(newDefault) {
-    this.#defaultNodeLabelFn = newDefault;
-    if (typeof newDefault !== 'function') {
-      this.#defaultNodeLabelFn = () => newDefault;
+  _createClass(Graph, [{
+    key: "isDirected",
+    value: function isDirected() {
+      return _classPrivateFieldGet(this, _isDirected);
     }
 
-    return this;
-  }
+    /**
+     * Whether graph was created with 'multigraph' flag set to true or not.
+     */
+  }, {
+    key: "isMultigraph",
+    value: function isMultigraph() {
+      return _classPrivateFieldGet(this, _isMultigraph);
+    }
 
-  /**
-   * Gets the number of nodes in the graph.
-   * Complexity: O(1).
-   */
-  nodeCount() {
-    return this.#nodeCount;
-  }
+    /**
+     * Whether graph was created with 'compound' flag set to true or not.
+     */
+  }, {
+    key: "isCompound",
+    value: function isCompound() {
+      return _classPrivateFieldGet(this, _isCompound);
+    }
 
-  /**
-   * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
-   * not included in list.
-   * Complexity: O(1).
-   */
-  nodes() {
-    return Object.keys(this.#nodes);
-  }
+    /**
+     * Sets the label of the graph.
+     */
+  }, {
+    key: "setGraph",
+    value: function setGraph(label) {
+      _classPrivateFieldSet(this, _label, label);
+      return this;
+    }
 
-  /**
-   * Gets list of nodes without in-edges.
-   * Complexity: O(|V|).
-   */
-  sources() {
-    var self = this;
-    return this.nodes().filter(v => Object.keys(self.#in[v]).length === 0);
-  }
+    /**
+     * Gets the graph label.
+     */
+  }, {
+    key: "graph",
+    value: function graph() {
+      return _classPrivateFieldGet(this, _label);
+    }
 
-  /**
-   * Gets list of nodes without out-edges.
-   * Complexity: O(|V|).
-   */
-  sinks() {
-    var self = this;
-    return this.nodes().filter(v => Object.keys(self.#out[v]).length === 0);
-  }
+    /* === Node functions ========== */
 
-  /**
-   * Invokes setNode method for each node in names list.
-   * Complexity: O(|names|).
-   */
-  setNodes(vs, value) {
-    var args = arguments;
-    var self = this;
-    vs.forEach(function(v) {
-      if (args.length > 1) {
-        self.setNode(v, value);
-      } else {
-        self.setNode(v);
-      }
-    });
-    return this;
-  }
-
-  /**
-   * Creates or updates the value for the node v in the graph. If label is supplied
-   * it is set as the value for the node. If label is not supplied and the node was
-   * created by this call then the default node label will be assigned.
-   * Complexity: O(1).
-   */
-  setNode(v, value) {
-    if (this.#nodes.hasOwnProperty(v)) {
-      if (arguments.length > 1) {
-        this.#nodes[v] = value;
+    /**
+     * Sets the default node label. If newDefault is a function, it will be
+     * invoked ach time when setting a label for a node. Otherwise, this label
+     * will be assigned as default label in case if no label was specified while
+     * setting a node.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "setDefaultNodeLabel",
+    value: function setDefaultNodeLabel(newDefault) {
+      _classPrivateFieldSet(this, _defaultNodeLabelFn, newDefault);
+      if (typeof newDefault !== 'function') {
+        _classPrivateFieldSet(this, _defaultNodeLabelFn, function () {
+          return newDefault;
+        });
       }
       return this;
     }
 
-    this.#nodes[v] = arguments.length > 1 ? value : this.#defaultNodeLabelFn(v);
-    if (this.#isCompound) {
-      this.#parent[v] = GRAPH_NODE;
-      this.#children[v] = {};
-      this.#children[GRAPH_NODE][v] = true;
+    /**
+     * Gets the number of nodes in the graph.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "nodeCount",
+    value: function nodeCount() {
+      return _classPrivateFieldGet(this, _nodeCount);
     }
-    this.#in[v] = {};
-    this.#preds[v] = {};
-    this.#out[v] = {};
-    this.#sucs[v] = {};
-    ++this.#nodeCount;
-    return this;
-  }
 
-  /**
-   * Gets the label of node with specified name.
-   * Complexity: O(|V|).
-   */
-  node(v) {
-    return this.#nodes[v];
-  }
+    /**
+     * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
+     * not included in list.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "nodes",
+    value: function nodes() {
+      return Object.keys(_classPrivateFieldGet(this, _nodes));
+    }
 
-  /**
-   * Detects whether graph has a node with specified name or not.
-   */
-  hasNode(v) {
-    return this.#nodes.hasOwnProperty(v);
-  }
+    /**
+     * Gets list of nodes without in-edges.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "sources",
+    value: function sources() {
+      var self = this;
+      return this.nodes().filter(function (v) {
+        return Object.keys(_classPrivateFieldGet(self, _in)[v]).length === 0;
+      });
+    }
 
-  /**
-   * Remove the node with the name from the graph or do nothing if the node is not in
-   * the graph. If the node was removed this function also removes any incident
-   * edges.
-   * Complexity: O(1).
-   */
-  removeNode(v) {
-    var self = this;
-    if (this.#nodes.hasOwnProperty(v)) {
-      var removeEdge = e => self.removeEdge(self.#edgeObjs[e]);
-      delete this.#nodes[v];
-      if (this.#isCompound) {
-        this.#removeFromParentsChildList(v);
-        delete this.#parent[v];
-        this.children(v).forEach(function(child) {
-          self.setParent(child);
-        });
-        delete this.#children[v];
+    /**
+     * Gets list of nodes without out-edges.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "sinks",
+    value: function sinks() {
+      var self = this;
+      return this.nodes().filter(function (v) {
+        return Object.keys(_classPrivateFieldGet(self, _out)[v]).length === 0;
+      });
+    }
+
+    /**
+     * Invokes setNode method for each node in names list.
+     * Complexity: O(|names|).
+     */
+  }, {
+    key: "setNodes",
+    value: function setNodes(vs, value) {
+      var args = arguments;
+      var self = this;
+      vs.forEach(function (v) {
+        if (args.length > 1) {
+          self.setNode(v, value);
+        } else {
+          self.setNode(v);
+        }
+      });
+      return this;
+    }
+
+    /**
+     * Creates or updates the value for the node v in the graph. If label is supplied
+     * it is set as the value for the node. If label is not supplied and the node was
+     * created by this call then the default node label will be assigned.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "setNode",
+    value: function setNode(v, value) {
+      var _this$nodeCount;
+      if (_classPrivateFieldGet(this, _nodes).hasOwnProperty(v)) {
+        if (arguments.length > 1) {
+          _classPrivateFieldGet(this, _nodes)[v] = value;
+        }
+        return this;
       }
-      Object.keys(this.#in[v]).forEach(removeEdge);
-      delete this.#in[v];
-      delete this.#preds[v];
-      Object.keys(this.#out[v]).forEach(removeEdge);
-      delete this.#out[v];
-      delete this.#sucs[v];
-      --this.#nodeCount;
-    }
-    return this;
-  }
-
-  /**
-   * Sets node p as a parent for node v if it is defined, or removes the
-   * parent for v if p is undefined. Method throws an exception in case of
-   * invoking it in context of noncompound graph.
-   * Average-case complexity: O(1).
-   */
-  setParent(v, parent) {
-    if (!this.#isCompound) {
-      throw new Error("Cannot set parent in a non-compound graph");
+      _classPrivateFieldGet(this, _nodes)[v] = arguments.length > 1 ? value : _classPrivateFieldGet(this, _defaultNodeLabelFn).call(this, v);
+      if (_classPrivateFieldGet(this, _isCompound)) {
+        _classPrivateFieldGet(this, _parent)[v] = GRAPH_NODE;
+        _classPrivateFieldGet(this, _children)[v] = {};
+        _classPrivateFieldGet(this, _children)[GRAPH_NODE][v] = true;
+      }
+      _classPrivateFieldGet(this, _in)[v] = {};
+      _classPrivateFieldGet(this, _preds)[v] = {};
+      _classPrivateFieldGet(this, _out)[v] = {};
+      _classPrivateFieldGet(this, _sucs)[v] = {};
+      _classPrivateFieldSet(this, _nodeCount, (_this$nodeCount = _classPrivateFieldGet(this, _nodeCount), ++_this$nodeCount));
+      return this;
     }
 
-    if (parent === undefined) {
-      parent = GRAPH_NODE;
-    } else {
-      // Coerce parent to string
-      parent += "";
-      for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
-        if (ancestor === v) {
-          throw new Error("Setting " + parent+ " as parent of " + v +
-              " would create a cycle");
+    /**
+     * Gets the label of node with specified name.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "node",
+    value: function node(v) {
+      return _classPrivateFieldGet(this, _nodes)[v];
+    }
+
+    /**
+     * Detects whether graph has a node with specified name or not.
+     */
+  }, {
+    key: "hasNode",
+    value: function hasNode(v) {
+      return _classPrivateFieldGet(this, _nodes).hasOwnProperty(v);
+    }
+
+    /**
+     * Remove the node with the name from the graph or do nothing if the node is not in
+     * the graph. If the node was removed this function also removes any incident
+     * edges.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "removeNode",
+    value: function removeNode(v) {
+      var self = this;
+      if (_classPrivateFieldGet(this, _nodes).hasOwnProperty(v)) {
+        var _this$nodeCount2;
+        var removeEdge = function removeEdge(e) {
+          return self.removeEdge(_classPrivateFieldGet(self, _edgeObjs)[e]);
+        };
+        delete _classPrivateFieldGet(this, _nodes)[v];
+        if (_classPrivateFieldGet(this, _isCompound)) {
+          _classPrivateMethodGet(this, _removeFromParentsChildList, _removeFromParentsChildList2).call(this, v);
+          delete _classPrivateFieldGet(this, _parent)[v];
+          this.children(v).forEach(function (child) {
+            self.setParent(child);
+          });
+          delete _classPrivateFieldGet(this, _children)[v];
+        }
+        Object.keys(_classPrivateFieldGet(this, _in)[v]).forEach(removeEdge);
+        delete _classPrivateFieldGet(this, _in)[v];
+        delete _classPrivateFieldGet(this, _preds)[v];
+        Object.keys(_classPrivateFieldGet(this, _out)[v]).forEach(removeEdge);
+        delete _classPrivateFieldGet(this, _out)[v];
+        delete _classPrivateFieldGet(this, _sucs)[v];
+        _classPrivateFieldSet(this, _nodeCount, (_this$nodeCount2 = _classPrivateFieldGet(this, _nodeCount), --_this$nodeCount2));
+      }
+      return this;
+    }
+
+    /**
+     * Sets node p as a parent for node v if it is defined, or removes the
+     * parent for v if p is undefined. Method throws an exception in case of
+     * invoking it in context of noncompound graph.
+     * Average-case complexity: O(1).
+     */
+  }, {
+    key: "setParent",
+    value: function setParent(v, parent) {
+      if (!_classPrivateFieldGet(this, _isCompound)) {
+        throw new Error("Cannot set parent in a non-compound graph");
+      }
+      if (parent === undefined) {
+        parent = GRAPH_NODE;
+      } else {
+        // Coerce parent to string
+        parent += "";
+        for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
+          if (ancestor === v) {
+            throw new Error("Setting " + parent + " as parent of " + v + " would create a cycle");
+          }
+        }
+        this.setNode(parent);
+      }
+      this.setNode(v);
+      _classPrivateMethodGet(this, _removeFromParentsChildList, _removeFromParentsChildList2).call(this, v);
+      _classPrivateFieldGet(this, _parent)[v] = parent;
+      _classPrivateFieldGet(this, _children)[parent][v] = true;
+      return this;
+    }
+  }, {
+    key: "parent",
+    value:
+    /**
+     * Gets parent node for node v.
+     * Complexity: O(1).
+     */
+    function parent(v) {
+      if (_classPrivateFieldGet(this, _isCompound)) {
+        var parent = _classPrivateFieldGet(this, _parent)[v];
+        if (parent !== GRAPH_NODE) {
+          return parent;
         }
       }
-
-      this.setNode(parent);
     }
 
-    this.setNode(v);
-    this.#removeFromParentsChildList(v);
-    this.#parent[v] = parent;
-    this.#children[parent][v] = true;
-    return this;
-  }
-
-  #removeFromParentsChildList(v) {
-    delete this.#children[this.#parent[v]][v];
-  }
-
-  /**
-   * Gets parent node for node v.
-   * Complexity: O(1).
-   */
-  parent(v) {
-    if (this.#isCompound) {
-      var parent = this.#parent[v];
-      if (parent !== GRAPH_NODE) {
-        return parent;
+    /**
+     * Gets list of direct children of node v.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "children",
+    value: function children() {
+      var v = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : GRAPH_NODE;
+      if (_classPrivateFieldGet(this, _isCompound)) {
+        var children = _classPrivateFieldGet(this, _children)[v];
+        if (children) {
+          return Object.keys(children);
+        }
+      } else if (v === GRAPH_NODE) {
+        return this.nodes();
+      } else if (this.hasNode(v)) {
+        return [];
       }
     }
-  }
 
-  /**
-   * Gets list of direct children of node v.
-   * Complexity: O(1).
-   */
-  children(v = GRAPH_NODE) {
-    if (this.#isCompound) {
-      var children = this.#children[v];
-      if (children) {
-        return Object.keys(children);
+    /**
+     * Return all nodes that are predecessors of the specified node or undefined if node v is not in
+     * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "predecessors",
+    value: function predecessors(v) {
+      var predsV = _classPrivateFieldGet(this, _preds)[v];
+      if (predsV) {
+        return Object.keys(predsV);
       }
-    } else if (v === GRAPH_NODE) {
-      return this.nodes();
-    } else if (this.hasNode(v)) {
-      return [];
     }
-  }
 
-  /**
-   * Return all nodes that are predecessors of the specified node or undefined if node v is not in
-   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
-   * Complexity: O(|V|).
-   */
-  predecessors(v) {
-    var predsV = this.#preds[v];
-    if (predsV) {
-      return Object.keys(predsV);
-    }
-  }
-
-  /**
-   * Return all nodes that are successors of the specified node or undefined if node v is not in
-   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
-   * Complexity: O(|V|).
-   */
-  successors(v) {
-    var sucsV = this.#sucs[v];
-    if (sucsV) {
-      return Object.keys(sucsV);
-    }
-  }
-
-  /**
-   * Return all nodes that are predecessors or successors of the specified node or undefined if
-   * node v is not in the graph.
-   * Complexity: O(|V|).
-   */
-  neighbors(v) {
-    var preds = this.predecessors(v);
-    if (preds) {
-      const union = new Set(preds);
-      for (var succ of this.successors(v)) {
-        union.add(succ);
+    /**
+     * Return all nodes that are successors of the specified node or undefined if node v is not in
+     * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "successors",
+    value: function successors(v) {
+      var sucsV = _classPrivateFieldGet(this, _sucs)[v];
+      if (sucsV) {
+        return Object.keys(sucsV);
       }
-
-      return Array.from(union.values());
     }
-  }
 
-  isLeaf(v) {
-    var neighbors;
-    if (this.isDirected()) {
-      neighbors = this.successors(v);
-    } else {
-      neighbors = this.neighbors(v);
+    /**
+     * Return all nodes that are predecessors or successors of the specified node or undefined if
+     * node v is not in the graph.
+     * Complexity: O(|V|).
+     */
+  }, {
+    key: "neighbors",
+    value: function neighbors(v) {
+      var preds = this.predecessors(v);
+      if (preds) {
+        var union = new Set(preds);
+        var _iterator = _createForOfIteratorHelper(this.successors(v)),
+          _step;
+        try {
+          for (_iterator.s(); !(_step = _iterator.n()).done;) {
+            var succ = _step.value;
+            union.add(succ);
+          }
+        } catch (err) {
+          _iterator.e(err);
+        } finally {
+          _iterator.f();
+        }
+        return Array.from(union.values());
+      }
     }
-    return neighbors.length === 0;
-  }
-
-  /**
-   * Creates new graph with nodes filtered via filter. Edges incident to rejected node
-   * are also removed. In case of compound graph, if parent is rejected by filter,
-   * than all its children are rejected too.
-   * Average-case complexity: O(|E|+|V|).
-   */
-  filterNodes(filter) {
-    var copy = new this.constructor({
-      directed: this.#isDirected,
-      multigraph: this.#isMultigraph,
-      compound: this.#isCompound
-    });
-
-    copy.setGraph(this.graph());
-
-    var self = this;
-    Object.entries(this.#nodes).forEach(function([v, value]) {
-      if (filter(v)) {
-        copy.setNode(v, value);
-      }
-    });
-
-    Object.values(this.#edgeObjs).forEach(function(e) {
-      if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
-        copy.setEdge(e, self.edge(e));
-      }
-    });
-
-    var parents = {};
-    function findParent(v) {
-      var parent = self.parent(v);
-      if (parent === undefined || copy.hasNode(parent)) {
-        parents[v] = parent;
-        return parent;
-      } else if (parent in parents) {
-        return parents[parent];
+  }, {
+    key: "isLeaf",
+    value: function isLeaf(v) {
+      var neighbors;
+      if (this.isDirected()) {
+        neighbors = this.successors(v);
       } else {
-        return findParent(parent);
+        neighbors = this.neighbors(v);
       }
+      return neighbors.length === 0;
     }
 
-    if (this.#isCompound) {
-      copy.nodes().forEach(v => copy.setParent(v, findParent(v)));
-    }
-
-    return copy;
-  }
-
-  /* === Edge functions ========== */
-
-  /**
-   * Sets the default edge label or factory function. This label will be
-   * assigned as default label in case if no label was specified while setting
-   * an edge or this function will be invoked each time when setting an edge
-   * with no label specified and returned value * will be used as a label for edge.
-   * Complexity: O(1).
-   */
-  setDefaultEdgeLabel(newDefault) {
-    this.#defaultEdgeLabelFn = newDefault;
-    if (typeof newDefault !== 'function') {
-      this.#defaultEdgeLabelFn = () => newDefault;
-    }
-
-    return this;
-  }
-
-  /**
-   * Gets the number of edges in the graph.
-   * Complexity: O(1).
-   */
-  edgeCount() {
-    return this.#edgeCount;
-  }
-
-  /**
-   * Gets edges of the graph. In case of compound graph subgraphs are not considered.
-   * Complexity: O(|E|).
-   */
-  edges() {
-    return Object.values(this.#edgeObjs);
-  }
-
-  /**
-   * Establish an edges path over the nodes in nodes list. If some edge is already
-   * exists, it will update its label, otherwise it will create an edge between pair
-   * of nodes with label provided or default label if no label provided.
-   * Complexity: O(|nodes|).
-   */
-  setPath(vs, value) {
-    var self = this;
-    var args = arguments;
-    vs.reduce(function(v, w) {
-      if (args.length > 1) {
-        self.setEdge(v, w, value);
-      } else {
-        self.setEdge(v, w);
+    /**
+     * Creates new graph with nodes filtered via filter. Edges incident to rejected node
+     * are also removed. In case of compound graph, if parent is rejected by filter,
+     * than all its children are rejected too.
+     * Average-case complexity: O(|E|+|V|).
+     */
+  }, {
+    key: "filterNodes",
+    value: function filterNodes(filter) {
+      var copy = new this.constructor({
+        directed: _classPrivateFieldGet(this, _isDirected),
+        multigraph: _classPrivateFieldGet(this, _isMultigraph),
+        compound: _classPrivateFieldGet(this, _isCompound)
+      });
+      copy.setGraph(this.graph());
+      var self = this;
+      Object.entries(_classPrivateFieldGet(this, _nodes)).forEach(function (_ref) {
+        var _ref2 = _slicedToArray(_ref, 2),
+          v = _ref2[0],
+          value = _ref2[1];
+        if (filter(v)) {
+          copy.setNode(v, value);
+        }
+      });
+      Object.values(_classPrivateFieldGet(this, _edgeObjs)).forEach(function (e) {
+        if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
+          copy.setEdge(e, self.edge(e));
+        }
+      });
+      var parents = {};
+      function findParent(v) {
+        var parent = self.parent(v);
+        if (parent === undefined || copy.hasNode(parent)) {
+          parents[v] = parent;
+          return parent;
+        } else if (parent in parents) {
+          return parents[parent];
+        } else {
+          return findParent(parent);
+        }
       }
-      return w;
-    });
-    return this;
-  }
-
-  /**
-   * Creates or updates the label for the edge (v, w) with the optionally supplied
-   * name. If label is supplied it is set as the value for the edge. If label is not
-   * supplied and the edge was created by this call then the default edge label will
-   * be assigned. The name parameter is only useful with multigraphs.
-   */
-  setEdge() {
-    var v, w, name, value;
-    var valueSpecified = false;
-    var arg0 = arguments[0];
-
-    if (typeof arg0 === "object" && arg0 !== null && "v" in arg0) {
-      v = arg0.v;
-      w = arg0.w;
-      name = arg0.name;
-      if (arguments.length === 2) {
-        value = arguments[1];
-        valueSpecified = true;
+      if (_classPrivateFieldGet(this, _isCompound)) {
+        copy.nodes().forEach(function (v) {
+          return copy.setParent(v, findParent(v));
+        });
       }
-    } else {
-      v = arg0;
-      w = arguments[1];
-      name = arguments[3];
-      if (arguments.length > 2) {
-        value = arguments[2];
-        valueSpecified = true;
-      }
+      return copy;
     }
 
-    v = "" + v;
-    w = "" + w;
-    if (name !== undefined) {
-      name = "" + name;
-    }
+    /* === Edge functions ========== */
 
-    var e = edgeArgsToId(this.#isDirected, v, w, name);
-    if (this.#edgeLabels.hasOwnProperty(e)) {
-      if (valueSpecified) {
-        this.#edgeLabels[e] = value;
+    /**
+     * Sets the default edge label or factory function. This label will be
+     * assigned as default label in case if no label was specified while setting
+     * an edge or this function will be invoked each time when setting an edge
+     * with no label specified and returned value * will be used as a label for edge.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "setDefaultEdgeLabel",
+    value: function setDefaultEdgeLabel(newDefault) {
+      _classPrivateFieldSet(this, _defaultEdgeLabelFn, newDefault);
+      if (typeof newDefault !== 'function') {
+        _classPrivateFieldSet(this, _defaultEdgeLabelFn, function () {
+          return newDefault;
+        });
       }
       return this;
     }
 
-    if (name !== undefined && !this.#isMultigraph) {
-      throw new Error("Cannot set a named edge when isMultigraph = false");
+    /**
+     * Gets the number of edges in the graph.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "edgeCount",
+    value: function edgeCount() {
+      return _classPrivateFieldGet(this, _edgeCount);
     }
 
-    // It didn't exist, so we need to create it.
-    // First ensure the nodes exist.
-    this.setNode(v);
-    this.setNode(w);
-
-    this.#edgeLabels[e] = valueSpecified ? value : this.#defaultEdgeLabelFn(v, w, name);
-
-    var edgeObj = edgeArgsToObj(this.#isDirected, v, w, name);
-    // Ensure we add undirected edges in a consistent way.
-    v = edgeObj.v;
-    w = edgeObj.w;
-
-    Object.freeze(edgeObj);
-    this.#edgeObjs[e] = edgeObj;
-    incrementOrInitEntry(this.#preds[w], v);
-    incrementOrInitEntry(this.#sucs[v], w);
-    this.#in[w][e] = edgeObj;
-    this.#out[v][e] = edgeObj;
-    this.#edgeCount++;
-    return this;
-  }
-
-  /**
-   * Gets the label for the specified edge.
-   * Complexity: O(1).
-   */
-  edge(v, w, name) {
-    var e = (arguments.length === 1
-      ? edgeObjToId(this.#isDirected, arguments[0])
-      : edgeArgsToId(this.#isDirected, v, w, name));
-    return this.#edgeLabels[e];
-  }
-
-  /**
-   * Gets the label for the specified edge and converts it to an object.
-   * Complexity: O(1)
-   */
-  edgeAsObj() {
-    const edge = this.edge(...arguments);
-    if (typeof edge !== "object") {
-      return {label: edge};
+    /**
+     * Gets edges of the graph. In case of compound graph subgraphs are not considered.
+     * Complexity: O(|E|).
+     */
+  }, {
+    key: "edges",
+    value: function edges() {
+      return Object.values(_classPrivateFieldGet(this, _edgeObjs));
     }
 
-    return edge;
-  }
-
-  /**
-   * Detects whether the graph contains specified edge or not. No subgraphs are considered.
-   * Complexity: O(1).
-   */
-  hasEdge(v, w, name) {
-    var e = (arguments.length === 1
-      ? edgeObjToId(this.#isDirected, arguments[0])
-      : edgeArgsToId(this.#isDirected, v, w, name));
-    return this.#edgeLabels.hasOwnProperty(e);
-  }
-
-  /**
-   * Removes the specified edge from the graph. No subgraphs are considered.
-   * Complexity: O(1).
-   */
-  removeEdge(v, w, name) {
-    var e = (arguments.length === 1
-      ? edgeObjToId(this.#isDirected, arguments[0])
-      : edgeArgsToId(this.#isDirected, v, w, name));
-    var edge = this.#edgeObjs[e];
-    if (edge) {
-      v = edge.v;
-      w = edge.w;
-      delete this.#edgeLabels[e];
-      delete this.#edgeObjs[e];
-      decrementOrRemoveEntry(this.#preds[w], v);
-      decrementOrRemoveEntry(this.#sucs[v], w);
-      delete this.#in[w][e];
-      delete this.#out[v][e];
-      this.#edgeCount--;
+    /**
+     * Establish an edges path over the nodes in nodes list. If some edge is already
+     * exists, it will update its label, otherwise it will create an edge between pair
+     * of nodes with label provided or default label if no label provided.
+     * Complexity: O(|nodes|).
+     */
+  }, {
+    key: "setPath",
+    value: function setPath(vs, value) {
+      var self = this;
+      var args = arguments;
+      vs.reduce(function (v, w) {
+        if (args.length > 1) {
+          self.setEdge(v, w, value);
+        } else {
+          self.setEdge(v, w);
+        }
+        return w;
+      });
+      return this;
     }
-    return this;
-  }
 
-  /**
-   * Return all edges that point to the node v. Optionally filters those edges down to just those
-   * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
-   * Complexity: O(|E|).
-   */
-  inEdges(v, u) {
-    var inV = this.#in[v];
-    if (inV) {
-      var edges = Object.values(inV);
-      if (!u) {
-        return edges;
+    /**
+     * Creates or updates the label for the edge (v, w) with the optionally supplied
+     * name. If label is supplied it is set as the value for the edge. If label is not
+     * supplied and the edge was created by this call then the default edge label will
+     * be assigned. The name parameter is only useful with multigraphs.
+     */
+  }, {
+    key: "setEdge",
+    value: function setEdge() {
+      var _this$edgeCount, _this$edgeCount2;
+      var v, w, name, value;
+      var valueSpecified = false;
+      var arg0 = arguments[0];
+      if (_typeof(arg0) === "object" && arg0 !== null && "v" in arg0) {
+        v = arg0.v;
+        w = arg0.w;
+        name = arg0.name;
+        if (arguments.length === 2) {
+          value = arguments[1];
+          valueSpecified = true;
+        }
+      } else {
+        v = arg0;
+        w = arguments[1];
+        name = arguments[3];
+        if (arguments.length > 2) {
+          value = arguments[2];
+          valueSpecified = true;
+        }
       }
-      return edges.filter(edge => edge.v === u);
-    }
-  }
-
-  /**
-   * Return all edges that are pointed at by node v. Optionally filters those edges down to just
-   * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
-   * Complexity: O(|E|).
-   */
-  outEdges(v, w) {
-    var outV = this.#out[v];
-    if (outV) {
-      var edges = Object.values(outV);
-      if (!w) {
-        return edges;
+      v = "" + v;
+      w = "" + w;
+      if (name !== undefined) {
+        name = "" + name;
       }
-      return edges.filter(edge => edge.w === w);
-    }
-  }
+      var e = edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
+      if (_classPrivateFieldGet(this, _edgeLabels).hasOwnProperty(e)) {
+        if (valueSpecified) {
+          _classPrivateFieldGet(this, _edgeLabels)[e] = value;
+        }
+        return this;
+      }
+      if (name !== undefined && !_classPrivateFieldGet(this, _isMultigraph)) {
+        throw new Error("Cannot set a named edge when isMultigraph = false");
+      }
 
-  /**
-   * Returns all edges to or from node v regardless of direction. Optionally filters those edges
-   * down to just those between nodes v and w regardless of direction.
-   * Complexity: O(|E|).
-   */
-  nodeEdges(v, w) {
-    var inEdges = this.inEdges(v, w);
-    if (inEdges) {
-      return inEdges.concat(this.outEdges(v, w));
+      // It didn't exist, so we need to create it.
+      // First ensure the nodes exist.
+      this.setNode(v);
+      this.setNode(w);
+      _classPrivateFieldGet(this, _edgeLabels)[e] = valueSpecified ? value : _classPrivateFieldGet(this, _defaultEdgeLabelFn).call(this, v, w, name);
+      var edgeObj = edgeArgsToObj(_classPrivateFieldGet(this, _isDirected), v, w, name);
+      // Ensure we add undirected edges in a consistent way.
+      v = edgeObj.v;
+      w = edgeObj.w;
+      Object.freeze(edgeObj);
+      _classPrivateFieldGet(this, _edgeObjs)[e] = edgeObj;
+      incrementOrInitEntry(_classPrivateFieldGet(this, _preds)[w], v);
+      incrementOrInitEntry(_classPrivateFieldGet(this, _sucs)[v], w);
+      _classPrivateFieldGet(this, _in)[w][e] = edgeObj;
+      _classPrivateFieldGet(this, _out)[v][e] = edgeObj;
+      _classPrivateFieldSet(this, _edgeCount, (_this$edgeCount = _classPrivateFieldGet(this, _edgeCount), _this$edgeCount2 = _this$edgeCount++, _this$edgeCount)), _this$edgeCount2;
+      return this;
     }
-  }
+
+    /**
+     * Gets the label for the specified edge.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "edge",
+    value: function edge(v, w, name) {
+      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
+      return _classPrivateFieldGet(this, _edgeLabels)[e];
+    }
+
+    /**
+     * Gets the label for the specified edge and converts it to an object.
+     * Complexity: O(1)
+     */
+  }, {
+    key: "edgeAsObj",
+    value: function edgeAsObj() {
+      var edge = this.edge.apply(this, arguments);
+      if (_typeof(edge) !== "object") {
+        return {
+          label: edge
+        };
+      }
+      return edge;
+    }
+
+    /**
+     * Detects whether the graph contains specified edge or not. No subgraphs are considered.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "hasEdge",
+    value: function hasEdge(v, w, name) {
+      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
+      return _classPrivateFieldGet(this, _edgeLabels).hasOwnProperty(e);
+    }
+
+    /**
+     * Removes the specified edge from the graph. No subgraphs are considered.
+     * Complexity: O(1).
+     */
+  }, {
+    key: "removeEdge",
+    value: function removeEdge(v, w, name) {
+      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
+      var edge = _classPrivateFieldGet(this, _edgeObjs)[e];
+      if (edge) {
+        var _this$edgeCount3, _this$edgeCount4;
+        v = edge.v;
+        w = edge.w;
+        delete _classPrivateFieldGet(this, _edgeLabels)[e];
+        delete _classPrivateFieldGet(this, _edgeObjs)[e];
+        decrementOrRemoveEntry(_classPrivateFieldGet(this, _preds)[w], v);
+        decrementOrRemoveEntry(_classPrivateFieldGet(this, _sucs)[v], w);
+        delete _classPrivateFieldGet(this, _in)[w][e];
+        delete _classPrivateFieldGet(this, _out)[v][e];
+        _classPrivateFieldSet(this, _edgeCount, (_this$edgeCount3 = _classPrivateFieldGet(this, _edgeCount), _this$edgeCount4 = _this$edgeCount3--, _this$edgeCount3)), _this$edgeCount4;
+      }
+      return this;
+    }
+
+    /**
+     * Return all edges that point to the node v. Optionally filters those edges down to just those
+     * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
+     * Complexity: O(|E|).
+     */
+  }, {
+    key: "inEdges",
+    value: function inEdges(v, u) {
+      var inV = _classPrivateFieldGet(this, _in)[v];
+      if (inV) {
+        var edges = Object.values(inV);
+        if (!u) {
+          return edges;
+        }
+        return edges.filter(function (edge) {
+          return edge.v === u;
+        });
+      }
+    }
+
+    /**
+     * Return all edges that are pointed at by node v. Optionally filters those edges down to just
+     * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
+     * Complexity: O(|E|).
+     */
+  }, {
+    key: "outEdges",
+    value: function outEdges(v, w) {
+      var outV = _classPrivateFieldGet(this, _out)[v];
+      if (outV) {
+        var edges = Object.values(outV);
+        if (!w) {
+          return edges;
+        }
+        return edges.filter(function (edge) {
+          return edge.w === w;
+        });
+      }
+    }
+
+    /**
+     * Returns all edges to or from node v regardless of direction. Optionally filters those edges
+     * down to just those between nodes v and w regardless of direction.
+     * Complexity: O(|E|).
+     */
+  }, {
+    key: "nodeEdges",
+    value: function nodeEdges(v, w) {
+      var inEdges = this.inEdges(v, w);
+      if (inEdges) {
+        return inEdges.concat(this.outEdges(v, w));
+      }
+    }
+  }]);
+  return Graph;
+}();
+function _removeFromParentsChildList2(v) {
+  delete _classPrivateFieldGet(this, _children)[_classPrivateFieldGet(this, _parent)[v]][v];
 }
-
 function incrementOrInitEntry(map, k) {
   if (map[k]) {
     map[k]++;
@@ -657,11 +816,11 @@ function incrementOrInitEntry(map, k) {
     map[k] = 1;
   }
 }
-
 function decrementOrRemoveEntry(map, k) {
-  if (!--map[k]) { delete map[k]; }
+  if (! --map[k]) {
+    delete map[k];
+  }
 }
-
 function edgeArgsToId(isDirected, v_, w_, name) {
   var v = "" + v_;
   var w = "" + w_;
@@ -670,10 +829,8 @@ function edgeArgsToId(isDirected, v_, w_, name) {
     v = w;
     w = tmp;
   }
-  return v + EDGE_KEY_DELIM + w + EDGE_KEY_DELIM +
-             (name === undefined ? DEFAULT_EDGE_NAME : name);
+  return v + EDGE_KEY_DELIM + w + EDGE_KEY_DELIM + (name === undefined ? DEFAULT_EDGE_NAME : name);
 }
-
 function edgeArgsToObj(isDirected, v_, w_, name) {
   var v = "" + v_;
   var w = "" + w_;
@@ -682,13 +839,15 @@ function edgeArgsToObj(isDirected, v_, w_, name) {
     v = w;
     w = tmp;
   }
-  var edgeObj =  { v: v, w: w };
+  var edgeObj = {
+    v: v,
+    w: w
+  };
   if (name) {
     edgeObj.name = name;
   }
   return edgeObj;
 }
-
 function edgeObjToId(isDirected, edgeObj) {
   return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
 }

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -3,29 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-function _classPrivateMethodInitSpec(obj, privateSet) { _checkPrivateRedeclaration(obj, privateSet); privateSet.add(obj); }
-function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
-function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
-function _classPrivateMethodGet(receiver, privateSet, fn) { if (!privateSet.has(receiver)) { throw new TypeError("attempted to get private field on non-instance"); } return fn; }
-function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
-function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
-function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"); _classApplyDescriptorSet(receiver, descriptor, value); return value; }
-function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
-function _classApplyDescriptorSet(receiver, descriptor, value) { if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } }
+exports.default = void 0;
 var DEFAULT_EDGE_NAME = "\x00";
 var GRAPH_NODE = "\x00";
 var EDGE_KEY_DELIM = "\x01";
@@ -39,124 +17,62 @@ var EDGE_KEY_DELIM = "\x01";
 //    reference edges. This is because we need a performant way to look these
 //    edges up and, object properties, which have string keys, are the closest
 //    we're going to get to a performant hashtable in JavaScript.
-var _isDirected = /*#__PURE__*/new WeakMap();
-var _isMultigraph = /*#__PURE__*/new WeakMap();
-var _isCompound = /*#__PURE__*/new WeakMap();
-var _label = /*#__PURE__*/new WeakMap();
-var _defaultNodeLabelFn = /*#__PURE__*/new WeakMap();
-var _defaultEdgeLabelFn = /*#__PURE__*/new WeakMap();
-var _nodes = /*#__PURE__*/new WeakMap();
-var _in = /*#__PURE__*/new WeakMap();
-var _preds = /*#__PURE__*/new WeakMap();
-var _out = /*#__PURE__*/new WeakMap();
-var _sucs = /*#__PURE__*/new WeakMap();
-var _edgeObjs = /*#__PURE__*/new WeakMap();
-var _edgeLabels = /*#__PURE__*/new WeakMap();
-var _nodeCount = /*#__PURE__*/new WeakMap();
-var _edgeCount = /*#__PURE__*/new WeakMap();
-var _parent = /*#__PURE__*/new WeakMap();
-var _children = /*#__PURE__*/new WeakMap();
-var _removeFromParentsChildList = /*#__PURE__*/new WeakSet();
-var Graph = exports["default"] = /*#__PURE__*/function () {
-  function Graph(opts) {
-    _classCallCheck(this, Graph);
-    _classPrivateMethodInitSpec(this, _removeFromParentsChildList);
-    _classPrivateFieldInitSpec(this, _isDirected, {
-      writable: true,
-      value: true
-    });
-    _classPrivateFieldInitSpec(this, _isMultigraph, {
-      writable: true,
-      value: false
-    });
-    _classPrivateFieldInitSpec(this, _isCompound, {
-      writable: true,
-      value: false
-    });
-    // Label for the graph itself
-    _classPrivateFieldInitSpec(this, _label, {
-      writable: true,
-      value: void 0
-    });
-    // Defaults to be set when creating a new node
-    _classPrivateFieldInitSpec(this, _defaultNodeLabelFn, {
-      writable: true,
-      value: function value() {
-        return undefined;
-      }
-    });
-    // Defaults to be set when creating a new edge
-    _classPrivateFieldInitSpec(this, _defaultEdgeLabelFn, {
-      writable: true,
-      value: function value() {
-        return undefined;
-      }
-    });
-    // v -> label
-    _classPrivateFieldInitSpec(this, _nodes, {
-      writable: true,
-      value: {}
-    });
-    // v -> edgeObj
-    _classPrivateFieldInitSpec(this, _in, {
-      writable: true,
-      value: {}
-    });
-    // u -> v -> Number
-    _classPrivateFieldInitSpec(this, _preds, {
-      writable: true,
-      value: {}
-    });
-    // v -> edgeObj
-    _classPrivateFieldInitSpec(this, _out, {
-      writable: true,
-      value: {}
-    });
-    // v -> w -> Number
-    _classPrivateFieldInitSpec(this, _sucs, {
-      writable: true,
-      value: {}
-    });
-    // e -> edgeObj
-    _classPrivateFieldInitSpec(this, _edgeObjs, {
-      writable: true,
-      value: {}
-    });
-    // e -> label
-    _classPrivateFieldInitSpec(this, _edgeLabels, {
-      writable: true,
-      value: {}
-    });
-    /* Number of nodes in the graph. Should only be changed by the implementation. */
-    _classPrivateFieldInitSpec(this, _nodeCount, {
-      writable: true,
-      value: 0
-    });
-    /* Number of edges in the graph. Should only be changed by the implementation. */
-    _classPrivateFieldInitSpec(this, _edgeCount, {
-      writable: true,
-      value: 0
-    });
-    _classPrivateFieldInitSpec(this, _parent, {
-      writable: true,
-      value: void 0
-    });
-    _classPrivateFieldInitSpec(this, _children, {
-      writable: true,
-      value: void 0
-    });
+
+class Graph {
+  #isDirected = true;
+  #isMultigraph = false;
+  #isCompound = false;
+
+  // Label for the graph itself
+  #label;
+
+  // Defaults to be set when creating a new node
+  #defaultNodeLabelFn = () => undefined;
+
+  // Defaults to be set when creating a new edge
+  #defaultEdgeLabelFn = () => undefined;
+
+  // v -> label
+  #nodes = {};
+
+  // v -> edgeObj
+  #in = {};
+
+  // u -> v -> Number
+  #preds = {};
+
+  // v -> edgeObj
+  #out = {};
+
+  // v -> w -> Number
+  #sucs = {};
+
+  // e -> edgeObj
+  #edgeObjs = {};
+
+  // e -> label
+  #edgeLabels = {};
+
+  /* Number of nodes in the graph. Should only be changed by the implementation. */
+  #nodeCount = 0;
+
+  /* Number of edges in the graph. Should only be changed by the implementation. */
+  #edgeCount = 0;
+  #parent;
+  #children;
+  constructor(opts) {
     if (opts) {
-      _classPrivateFieldSet(this, _isDirected, opts.hasOwnProperty("directed") ? opts.directed : true);
-      _classPrivateFieldSet(this, _isMultigraph, opts.hasOwnProperty("multigraph") ? opts.multigraph : false);
-      _classPrivateFieldSet(this, _isCompound, opts.hasOwnProperty("compound") ? opts.compound : false);
+      this.#isDirected = opts.hasOwnProperty("directed") ? opts.directed : true;
+      this.#isMultigraph = opts.hasOwnProperty("multigraph") ? opts.multigraph : false;
+      this.#isCompound = opts.hasOwnProperty("compound") ? opts.compound : false;
     }
-    if (_classPrivateFieldGet(this, _isCompound)) {
+    if (this.#isCompound) {
       // v -> parent
-      _classPrivateFieldSet(this, _parent, {});
+      this.#parent = {};
 
       // v -> children
-      _classPrivateFieldSet(this, _children, {});
-      _classPrivateFieldGet(this, _children)[GRAPH_NODE] = {};
+      this.#children = {};
+      this.#children[GRAPH_NODE] = {};
     }
   }
 
@@ -165,650 +81,546 @@ var Graph = exports["default"] = /*#__PURE__*/function () {
   /**
    * Whether graph was created with 'directed' flag set to true or not.
    */
-  _createClass(Graph, [{
-    key: "isDirected",
-    value: function isDirected() {
-      return _classPrivateFieldGet(this, _isDirected);
+  isDirected() {
+    return this.#isDirected;
+  }
+
+  /**
+   * Whether graph was created with 'multigraph' flag set to true or not.
+   */
+  isMultigraph() {
+    return this.#isMultigraph;
+  }
+
+  /**
+   * Whether graph was created with 'compound' flag set to true or not.
+   */
+  isCompound() {
+    return this.#isCompound;
+  }
+
+  /**
+   * Sets the label of the graph.
+   */
+  setGraph(label) {
+    this.#label = label;
+    return this;
+  }
+
+  /**
+   * Gets the graph label.
+   */
+  graph() {
+    return this.#label;
+  }
+
+  /* === Node functions ========== */
+
+  /**
+   * Sets the default node label. If newDefault is a function, it will be
+   * invoked ach time when setting a label for a node. Otherwise, this label
+   * will be assigned as default label in case if no label was specified while
+   * setting a node.
+   * Complexity: O(1).
+   */
+  setDefaultNodeLabel(newDefault) {
+    this.#defaultNodeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultNodeLabelFn = () => newDefault;
     }
+    return this;
+  }
 
-    /**
-     * Whether graph was created with 'multigraph' flag set to true or not.
-     */
-  }, {
-    key: "isMultigraph",
-    value: function isMultigraph() {
-      return _classPrivateFieldGet(this, _isMultigraph);
-    }
+  /**
+   * Gets the number of nodes in the graph.
+   * Complexity: O(1).
+   */
+  nodeCount() {
+    return this.#nodeCount;
+  }
 
-    /**
-     * Whether graph was created with 'compound' flag set to true or not.
-     */
-  }, {
-    key: "isCompound",
-    value: function isCompound() {
-      return _classPrivateFieldGet(this, _isCompound);
-    }
+  /**
+   * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
+   * not included in list.
+   * Complexity: O(1).
+   */
+  nodes() {
+    return Object.keys(this.#nodes);
+  }
 
-    /**
-     * Sets the label of the graph.
-     */
-  }, {
-    key: "setGraph",
-    value: function setGraph(label) {
-      _classPrivateFieldSet(this, _label, label);
-      return this;
-    }
+  /**
+   * Gets list of nodes without in-edges.
+   * Complexity: O(|V|).
+   */
+  sources() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#in[v]).length === 0);
+  }
 
-    /**
-     * Gets the graph label.
-     */
-  }, {
-    key: "graph",
-    value: function graph() {
-      return _classPrivateFieldGet(this, _label);
-    }
+  /**
+   * Gets list of nodes without out-edges.
+   * Complexity: O(|V|).
+   */
+  sinks() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#out[v]).length === 0);
+  }
 
-    /* === Node functions ========== */
-
-    /**
-     * Sets the default node label. If newDefault is a function, it will be
-     * invoked ach time when setting a label for a node. Otherwise, this label
-     * will be assigned as default label in case if no label was specified while
-     * setting a node.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "setDefaultNodeLabel",
-    value: function setDefaultNodeLabel(newDefault) {
-      _classPrivateFieldSet(this, _defaultNodeLabelFn, newDefault);
-      if (typeof newDefault !== 'function') {
-        _classPrivateFieldSet(this, _defaultNodeLabelFn, function () {
-          return newDefault;
-        });
-      }
-      return this;
-    }
-
-    /**
-     * Gets the number of nodes in the graph.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "nodeCount",
-    value: function nodeCount() {
-      return _classPrivateFieldGet(this, _nodeCount);
-    }
-
-    /**
-     * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
-     * not included in list.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "nodes",
-    value: function nodes() {
-      return Object.keys(_classPrivateFieldGet(this, _nodes));
-    }
-
-    /**
-     * Gets list of nodes without in-edges.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "sources",
-    value: function sources() {
-      var self = this;
-      return this.nodes().filter(function (v) {
-        return Object.keys(_classPrivateFieldGet(self, _in)[v]).length === 0;
-      });
-    }
-
-    /**
-     * Gets list of nodes without out-edges.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "sinks",
-    value: function sinks() {
-      var self = this;
-      return this.nodes().filter(function (v) {
-        return Object.keys(_classPrivateFieldGet(self, _out)[v]).length === 0;
-      });
-    }
-
-    /**
-     * Invokes setNode method for each node in names list.
-     * Complexity: O(|names|).
-     */
-  }, {
-    key: "setNodes",
-    value: function setNodes(vs, value) {
-      var args = arguments;
-      var self = this;
-      vs.forEach(function (v) {
-        if (args.length > 1) {
-          self.setNode(v, value);
-        } else {
-          self.setNode(v);
-        }
-      });
-      return this;
-    }
-
-    /**
-     * Creates or updates the value for the node v in the graph. If label is supplied
-     * it is set as the value for the node. If label is not supplied and the node was
-     * created by this call then the default node label will be assigned.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "setNode",
-    value: function setNode(v, value) {
-      var _this$nodeCount;
-      if (_classPrivateFieldGet(this, _nodes).hasOwnProperty(v)) {
-        if (arguments.length > 1) {
-          _classPrivateFieldGet(this, _nodes)[v] = value;
-        }
-        return this;
-      }
-      _classPrivateFieldGet(this, _nodes)[v] = arguments.length > 1 ? value : _classPrivateFieldGet(this, _defaultNodeLabelFn).call(this, v);
-      if (_classPrivateFieldGet(this, _isCompound)) {
-        _classPrivateFieldGet(this, _parent)[v] = GRAPH_NODE;
-        _classPrivateFieldGet(this, _children)[v] = {};
-        _classPrivateFieldGet(this, _children)[GRAPH_NODE][v] = true;
-      }
-      _classPrivateFieldGet(this, _in)[v] = {};
-      _classPrivateFieldGet(this, _preds)[v] = {};
-      _classPrivateFieldGet(this, _out)[v] = {};
-      _classPrivateFieldGet(this, _sucs)[v] = {};
-      _classPrivateFieldSet(this, _nodeCount, (_this$nodeCount = _classPrivateFieldGet(this, _nodeCount), ++_this$nodeCount));
-      return this;
-    }
-
-    /**
-     * Gets the label of node with specified name.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "node",
-    value: function node(v) {
-      return _classPrivateFieldGet(this, _nodes)[v];
-    }
-
-    /**
-     * Detects whether graph has a node with specified name or not.
-     */
-  }, {
-    key: "hasNode",
-    value: function hasNode(v) {
-      return _classPrivateFieldGet(this, _nodes).hasOwnProperty(v);
-    }
-
-    /**
-     * Remove the node with the name from the graph or do nothing if the node is not in
-     * the graph. If the node was removed this function also removes any incident
-     * edges.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "removeNode",
-    value: function removeNode(v) {
-      var self = this;
-      if (_classPrivateFieldGet(this, _nodes).hasOwnProperty(v)) {
-        var _this$nodeCount2;
-        var removeEdge = function removeEdge(e) {
-          return self.removeEdge(_classPrivateFieldGet(self, _edgeObjs)[e]);
-        };
-        delete _classPrivateFieldGet(this, _nodes)[v];
-        if (_classPrivateFieldGet(this, _isCompound)) {
-          _classPrivateMethodGet(this, _removeFromParentsChildList, _removeFromParentsChildList2).call(this, v);
-          delete _classPrivateFieldGet(this, _parent)[v];
-          this.children(v).forEach(function (child) {
-            self.setParent(child);
-          });
-          delete _classPrivateFieldGet(this, _children)[v];
-        }
-        Object.keys(_classPrivateFieldGet(this, _in)[v]).forEach(removeEdge);
-        delete _classPrivateFieldGet(this, _in)[v];
-        delete _classPrivateFieldGet(this, _preds)[v];
-        Object.keys(_classPrivateFieldGet(this, _out)[v]).forEach(removeEdge);
-        delete _classPrivateFieldGet(this, _out)[v];
-        delete _classPrivateFieldGet(this, _sucs)[v];
-        _classPrivateFieldSet(this, _nodeCount, (_this$nodeCount2 = _classPrivateFieldGet(this, _nodeCount), --_this$nodeCount2));
-      }
-      return this;
-    }
-
-    /**
-     * Sets node p as a parent for node v if it is defined, or removes the
-     * parent for v if p is undefined. Method throws an exception in case of
-     * invoking it in context of noncompound graph.
-     * Average-case complexity: O(1).
-     */
-  }, {
-    key: "setParent",
-    value: function setParent(v, parent) {
-      if (!_classPrivateFieldGet(this, _isCompound)) {
-        throw new Error("Cannot set parent in a non-compound graph");
-      }
-      if (parent === undefined) {
-        parent = GRAPH_NODE;
+  /**
+   * Invokes setNode method for each node in names list.
+   * Complexity: O(|names|).
+   */
+  setNodes(vs, value) {
+    var args = arguments;
+    var self = this;
+    vs.forEach(function (v) {
+      if (args.length > 1) {
+        self.setNode(v, value);
       } else {
-        // Coerce parent to string
-        parent += "";
-        for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
-          if (ancestor === v) {
-            throw new Error("Setting " + parent + " as parent of " + v + " would create a cycle");
-          }
-        }
-        this.setNode(parent);
+        self.setNode(v);
       }
-      this.setNode(v);
-      _classPrivateMethodGet(this, _removeFromParentsChildList, _removeFromParentsChildList2).call(this, v);
-      _classPrivateFieldGet(this, _parent)[v] = parent;
-      _classPrivateFieldGet(this, _children)[parent][v] = true;
+    });
+    return this;
+  }
+
+  /**
+   * Creates or updates the value for the node v in the graph. If label is supplied
+   * it is set as the value for the node. If label is not supplied and the node was
+   * created by this call then the default node label will be assigned.
+   * Complexity: O(1).
+   */
+  setNode(v, value) {
+    if (this.#nodes.hasOwnProperty(v)) {
+      if (arguments.length > 1) {
+        this.#nodes[v] = value;
+      }
       return this;
     }
-  }, {
-    key: "parent",
-    value:
-    /**
-     * Gets parent node for node v.
-     * Complexity: O(1).
-     */
-    function parent(v) {
-      if (_classPrivateFieldGet(this, _isCompound)) {
-        var parent = _classPrivateFieldGet(this, _parent)[v];
-        if (parent !== GRAPH_NODE) {
-          return parent;
+    this.#nodes[v] = arguments.length > 1 ? value : this.#defaultNodeLabelFn(v);
+    if (this.#isCompound) {
+      this.#parent[v] = GRAPH_NODE;
+      this.#children[v] = {};
+      this.#children[GRAPH_NODE][v] = true;
+    }
+    this.#in[v] = {};
+    this.#preds[v] = {};
+    this.#out[v] = {};
+    this.#sucs[v] = {};
+    ++this.#nodeCount;
+    return this;
+  }
+
+  /**
+   * Gets the label of node with specified name.
+   * Complexity: O(|V|).
+   */
+  node(v) {
+    return this.#nodes[v];
+  }
+
+  /**
+   * Detects whether graph has a node with specified name or not.
+   */
+  hasNode(v) {
+    return this.#nodes.hasOwnProperty(v);
+  }
+
+  /**
+   * Remove the node with the name from the graph or do nothing if the node is not in
+   * the graph. If the node was removed this function also removes any incident
+   * edges.
+   * Complexity: O(1).
+   */
+  removeNode(v) {
+    var self = this;
+    if (this.#nodes.hasOwnProperty(v)) {
+      var removeEdge = e => self.removeEdge(self.#edgeObjs[e]);
+      delete this.#nodes[v];
+      if (this.#isCompound) {
+        this.#removeFromParentsChildList(v);
+        delete this.#parent[v];
+        this.children(v).forEach(function (child) {
+          self.setParent(child);
+        });
+        delete this.#children[v];
+      }
+      Object.keys(this.#in[v]).forEach(removeEdge);
+      delete this.#in[v];
+      delete this.#preds[v];
+      Object.keys(this.#out[v]).forEach(removeEdge);
+      delete this.#out[v];
+      delete this.#sucs[v];
+      --this.#nodeCount;
+    }
+    return this;
+  }
+
+  /**
+   * Sets node p as a parent for node v if it is defined, or removes the
+   * parent for v if p is undefined. Method throws an exception in case of
+   * invoking it in context of noncompound graph.
+   * Average-case complexity: O(1).
+   */
+  setParent(v, parent) {
+    if (!this.#isCompound) {
+      throw new Error("Cannot set parent in a non-compound graph");
+    }
+    if (parent === undefined) {
+      parent = GRAPH_NODE;
+    } else {
+      // Coerce parent to string
+      parent += "";
+      for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
+        if (ancestor === v) {
+          throw new Error("Setting " + parent + " as parent of " + v + " would create a cycle");
         }
       }
+      this.setNode(parent);
     }
+    this.setNode(v);
+    this.#removeFromParentsChildList(v);
+    this.#parent[v] = parent;
+    this.#children[parent][v] = true;
+    return this;
+  }
+  #removeFromParentsChildList(v) {
+    delete this.#children[this.#parent[v]][v];
+  }
 
-    /**
-     * Gets list of direct children of node v.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "children",
-    value: function children() {
-      var v = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : GRAPH_NODE;
-      if (_classPrivateFieldGet(this, _isCompound)) {
-        var children = _classPrivateFieldGet(this, _children)[v];
-        if (children) {
-          return Object.keys(children);
-        }
-      } else if (v === GRAPH_NODE) {
-        return this.nodes();
-      } else if (this.hasNode(v)) {
-        return [];
+  /**
+   * Gets parent node for node v.
+   * Complexity: O(1).
+   */
+  parent(v) {
+    if (this.#isCompound) {
+      var parent = this.#parent[v];
+      if (parent !== GRAPH_NODE) {
+        return parent;
       }
     }
+  }
 
-    /**
-     * Return all nodes that are predecessors of the specified node or undefined if node v is not in
-     * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "predecessors",
-    value: function predecessors(v) {
-      var predsV = _classPrivateFieldGet(this, _preds)[v];
-      if (predsV) {
-        return Object.keys(predsV);
+  /**
+   * Gets list of direct children of node v.
+   * Complexity: O(1).
+   */
+  children(v = GRAPH_NODE) {
+    if (this.#isCompound) {
+      var children = this.#children[v];
+      if (children) {
+        return Object.keys(children);
       }
+    } else if (v === GRAPH_NODE) {
+      return this.nodes();
+    } else if (this.hasNode(v)) {
+      return [];
     }
+  }
 
-    /**
-     * Return all nodes that are successors of the specified node or undefined if node v is not in
-     * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "successors",
-    value: function successors(v) {
-      var sucsV = _classPrivateFieldGet(this, _sucs)[v];
-      if (sucsV) {
-        return Object.keys(sucsV);
-      }
+  /**
+   * Return all nodes that are predecessors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  predecessors(v) {
+    var predsV = this.#preds[v];
+    if (predsV) {
+      return Object.keys(predsV);
     }
+  }
 
-    /**
-     * Return all nodes that are predecessors or successors of the specified node or undefined if
-     * node v is not in the graph.
-     * Complexity: O(|V|).
-     */
-  }, {
-    key: "neighbors",
-    value: function neighbors(v) {
-      var preds = this.predecessors(v);
-      if (preds) {
-        var union = new Set(preds);
-        var _iterator = _createForOfIteratorHelper(this.successors(v)),
-          _step;
-        try {
-          for (_iterator.s(); !(_step = _iterator.n()).done;) {
-            var succ = _step.value;
-            union.add(succ);
-          }
-        } catch (err) {
-          _iterator.e(err);
-        } finally {
-          _iterator.f();
-        }
-        return Array.from(union.values());
-      }
+  /**
+   * Return all nodes that are successors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  successors(v) {
+    var sucsV = this.#sucs[v];
+    if (sucsV) {
+      return Object.keys(sucsV);
     }
-  }, {
-    key: "isLeaf",
-    value: function isLeaf(v) {
-      var neighbors;
-      if (this.isDirected()) {
-        neighbors = this.successors(v);
+  }
+
+  /**
+   * Return all nodes that are predecessors or successors of the specified node or undefined if
+   * node v is not in the graph.
+   * Complexity: O(|V|).
+   */
+  neighbors(v) {
+    var preds = this.predecessors(v);
+    if (preds) {
+      const union = new Set(preds);
+      for (var succ of this.successors(v)) {
+        union.add(succ);
+      }
+      return Array.from(union.values());
+    }
+  }
+  isLeaf(v) {
+    var neighbors;
+    if (this.isDirected()) {
+      neighbors = this.successors(v);
+    } else {
+      neighbors = this.neighbors(v);
+    }
+    return neighbors.length === 0;
+  }
+
+  /**
+   * Creates new graph with nodes filtered via filter. Edges incident to rejected node
+   * are also removed. In case of compound graph, if parent is rejected by filter,
+   * than all its children are rejected too.
+   * Average-case complexity: O(|E|+|V|).
+   */
+  filterNodes(filter) {
+    var copy = new this.constructor({
+      directed: this.#isDirected,
+      multigraph: this.#isMultigraph,
+      compound: this.#isCompound
+    });
+    copy.setGraph(this.graph());
+    var self = this;
+    Object.entries(this.#nodes).forEach(function ([v, value]) {
+      if (filter(v)) {
+        copy.setNode(v, value);
+      }
+    });
+    Object.values(this.#edgeObjs).forEach(function (e) {
+      if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
+        copy.setEdge(e, self.edge(e));
+      }
+    });
+    var parents = {};
+    function findParent(v) {
+      var parent = self.parent(v);
+      if (parent === undefined || copy.hasNode(parent)) {
+        parents[v] = parent;
+        return parent;
+      } else if (parent in parents) {
+        return parents[parent];
       } else {
-        neighbors = this.neighbors(v);
+        return findParent(parent);
       }
-      return neighbors.length === 0;
     }
-
-    /**
-     * Creates new graph with nodes filtered via filter. Edges incident to rejected node
-     * are also removed. In case of compound graph, if parent is rejected by filter,
-     * than all its children are rejected too.
-     * Average-case complexity: O(|E|+|V|).
-     */
-  }, {
-    key: "filterNodes",
-    value: function filterNodes(filter) {
-      var copy = new this.constructor({
-        directed: _classPrivateFieldGet(this, _isDirected),
-        multigraph: _classPrivateFieldGet(this, _isMultigraph),
-        compound: _classPrivateFieldGet(this, _isCompound)
-      });
-      copy.setGraph(this.graph());
-      var self = this;
-      Object.entries(_classPrivateFieldGet(this, _nodes)).forEach(function (_ref) {
-        var _ref2 = _slicedToArray(_ref, 2),
-          v = _ref2[0],
-          value = _ref2[1];
-        if (filter(v)) {
-          copy.setNode(v, value);
-        }
-      });
-      Object.values(_classPrivateFieldGet(this, _edgeObjs)).forEach(function (e) {
-        if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
-          copy.setEdge(e, self.edge(e));
-        }
-      });
-      var parents = {};
-      function findParent(v) {
-        var parent = self.parent(v);
-        if (parent === undefined || copy.hasNode(parent)) {
-          parents[v] = parent;
-          return parent;
-        } else if (parent in parents) {
-          return parents[parent];
-        } else {
-          return findParent(parent);
-        }
-      }
-      if (_classPrivateFieldGet(this, _isCompound)) {
-        copy.nodes().forEach(function (v) {
-          return copy.setParent(v, findParent(v));
-        });
-      }
-      return copy;
+    if (this.#isCompound) {
+      copy.nodes().forEach(v => copy.setParent(v, findParent(v)));
     }
+    return copy;
+  }
 
-    /* === Edge functions ========== */
+  /* === Edge functions ========== */
 
-    /**
-     * Sets the default edge label or factory function. This label will be
-     * assigned as default label in case if no label was specified while setting
-     * an edge or this function will be invoked each time when setting an edge
-     * with no label specified and returned value * will be used as a label for edge.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "setDefaultEdgeLabel",
-    value: function setDefaultEdgeLabel(newDefault) {
-      _classPrivateFieldSet(this, _defaultEdgeLabelFn, newDefault);
-      if (typeof newDefault !== 'function') {
-        _classPrivateFieldSet(this, _defaultEdgeLabelFn, function () {
-          return newDefault;
-        });
-      }
-      return this;
+  /**
+   * Sets the default edge label or factory function. This label will be
+   * assigned as default label in case if no label was specified while setting
+   * an edge or this function will be invoked each time when setting an edge
+   * with no label specified and returned value * will be used as a label for edge.
+   * Complexity: O(1).
+   */
+  setDefaultEdgeLabel(newDefault) {
+    this.#defaultEdgeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultEdgeLabelFn = () => newDefault;
     }
+    return this;
+  }
 
-    /**
-     * Gets the number of edges in the graph.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "edgeCount",
-    value: function edgeCount() {
-      return _classPrivateFieldGet(this, _edgeCount);
-    }
+  /**
+   * Gets the number of edges in the graph.
+   * Complexity: O(1).
+   */
+  edgeCount() {
+    return this.#edgeCount;
+  }
 
-    /**
-     * Gets edges of the graph. In case of compound graph subgraphs are not considered.
-     * Complexity: O(|E|).
-     */
-  }, {
-    key: "edges",
-    value: function edges() {
-      return Object.values(_classPrivateFieldGet(this, _edgeObjs));
-    }
+  /**
+   * Gets edges of the graph. In case of compound graph subgraphs are not considered.
+   * Complexity: O(|E|).
+   */
+  edges() {
+    return Object.values(this.#edgeObjs);
+  }
 
-    /**
-     * Establish an edges path over the nodes in nodes list. If some edge is already
-     * exists, it will update its label, otherwise it will create an edge between pair
-     * of nodes with label provided or default label if no label provided.
-     * Complexity: O(|nodes|).
-     */
-  }, {
-    key: "setPath",
-    value: function setPath(vs, value) {
-      var self = this;
-      var args = arguments;
-      vs.reduce(function (v, w) {
-        if (args.length > 1) {
-          self.setEdge(v, w, value);
-        } else {
-          self.setEdge(v, w);
-        }
-        return w;
-      });
-      return this;
-    }
-
-    /**
-     * Creates or updates the label for the edge (v, w) with the optionally supplied
-     * name. If label is supplied it is set as the value for the edge. If label is not
-     * supplied and the edge was created by this call then the default edge label will
-     * be assigned. The name parameter is only useful with multigraphs.
-     */
-  }, {
-    key: "setEdge",
-    value: function setEdge() {
-      var _this$edgeCount, _this$edgeCount2;
-      var v, w, name, value;
-      var valueSpecified = false;
-      var arg0 = arguments[0];
-      if (_typeof(arg0) === "object" && arg0 !== null && "v" in arg0) {
-        v = arg0.v;
-        w = arg0.w;
-        name = arg0.name;
-        if (arguments.length === 2) {
-          value = arguments[1];
-          valueSpecified = true;
-        }
+  /**
+   * Establish an edges path over the nodes in nodes list. If some edge is already
+   * exists, it will update its label, otherwise it will create an edge between pair
+   * of nodes with label provided or default label if no label provided.
+   * Complexity: O(|nodes|).
+   */
+  setPath(vs, value) {
+    var self = this;
+    var args = arguments;
+    vs.reduce(function (v, w) {
+      if (args.length > 1) {
+        self.setEdge(v, w, value);
       } else {
-        v = arg0;
-        w = arguments[1];
-        name = arguments[3];
-        if (arguments.length > 2) {
-          value = arguments[2];
-          valueSpecified = true;
-        }
+        self.setEdge(v, w);
       }
-      v = "" + v;
-      w = "" + w;
-      if (name !== undefined) {
-        name = "" + name;
-      }
-      var e = edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
-      if (_classPrivateFieldGet(this, _edgeLabels).hasOwnProperty(e)) {
-        if (valueSpecified) {
-          _classPrivateFieldGet(this, _edgeLabels)[e] = value;
-        }
-        return this;
-      }
-      if (name !== undefined && !_classPrivateFieldGet(this, _isMultigraph)) {
-        throw new Error("Cannot set a named edge when isMultigraph = false");
-      }
+      return w;
+    });
+    return this;
+  }
 
-      // It didn't exist, so we need to create it.
-      // First ensure the nodes exist.
-      this.setNode(v);
-      this.setNode(w);
-      _classPrivateFieldGet(this, _edgeLabels)[e] = valueSpecified ? value : _classPrivateFieldGet(this, _defaultEdgeLabelFn).call(this, v, w, name);
-      var edgeObj = edgeArgsToObj(_classPrivateFieldGet(this, _isDirected), v, w, name);
-      // Ensure we add undirected edges in a consistent way.
-      v = edgeObj.v;
-      w = edgeObj.w;
-      Object.freeze(edgeObj);
-      _classPrivateFieldGet(this, _edgeObjs)[e] = edgeObj;
-      incrementOrInitEntry(_classPrivateFieldGet(this, _preds)[w], v);
-      incrementOrInitEntry(_classPrivateFieldGet(this, _sucs)[v], w);
-      _classPrivateFieldGet(this, _in)[w][e] = edgeObj;
-      _classPrivateFieldGet(this, _out)[v][e] = edgeObj;
-      _classPrivateFieldSet(this, _edgeCount, (_this$edgeCount = _classPrivateFieldGet(this, _edgeCount), _this$edgeCount2 = _this$edgeCount++, _this$edgeCount)), _this$edgeCount2;
-      return this;
+  /**
+   * Creates or updates the label for the edge (v, w) with the optionally supplied
+   * name. If label is supplied it is set as the value for the edge. If label is not
+   * supplied and the edge was created by this call then the default edge label will
+   * be assigned. The name parameter is only useful with multigraphs.
+   */
+  setEdge() {
+    var v, w, name, value;
+    var valueSpecified = false;
+    var arg0 = arguments[0];
+    if (typeof arg0 === "object" && arg0 !== null && "v" in arg0) {
+      v = arg0.v;
+      w = arg0.w;
+      name = arg0.name;
+      if (arguments.length === 2) {
+        value = arguments[1];
+        valueSpecified = true;
+      }
+    } else {
+      v = arg0;
+      w = arguments[1];
+      name = arguments[3];
+      if (arguments.length > 2) {
+        value = arguments[2];
+        valueSpecified = true;
+      }
     }
-
-    /**
-     * Gets the label for the specified edge.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "edge",
-    value: function edge(v, w, name) {
-      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
-      return _classPrivateFieldGet(this, _edgeLabels)[e];
+    v = "" + v;
+    w = "" + w;
+    if (name !== undefined) {
+      name = "" + name;
     }
-
-    /**
-     * Gets the label for the specified edge and converts it to an object.
-     * Complexity: O(1)
-     */
-  }, {
-    key: "edgeAsObj",
-    value: function edgeAsObj() {
-      var edge = this.edge.apply(this, arguments);
-      if (_typeof(edge) !== "object") {
-        return {
-          label: edge
-        };
-      }
-      return edge;
-    }
-
-    /**
-     * Detects whether the graph contains specified edge or not. No subgraphs are considered.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "hasEdge",
-    value: function hasEdge(v, w, name) {
-      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
-      return _classPrivateFieldGet(this, _edgeLabels).hasOwnProperty(e);
-    }
-
-    /**
-     * Removes the specified edge from the graph. No subgraphs are considered.
-     * Complexity: O(1).
-     */
-  }, {
-    key: "removeEdge",
-    value: function removeEdge(v, w, name) {
-      var e = arguments.length === 1 ? edgeObjToId(_classPrivateFieldGet(this, _isDirected), arguments[0]) : edgeArgsToId(_classPrivateFieldGet(this, _isDirected), v, w, name);
-      var edge = _classPrivateFieldGet(this, _edgeObjs)[e];
-      if (edge) {
-        var _this$edgeCount3, _this$edgeCount4;
-        v = edge.v;
-        w = edge.w;
-        delete _classPrivateFieldGet(this, _edgeLabels)[e];
-        delete _classPrivateFieldGet(this, _edgeObjs)[e];
-        decrementOrRemoveEntry(_classPrivateFieldGet(this, _preds)[w], v);
-        decrementOrRemoveEntry(_classPrivateFieldGet(this, _sucs)[v], w);
-        delete _classPrivateFieldGet(this, _in)[w][e];
-        delete _classPrivateFieldGet(this, _out)[v][e];
-        _classPrivateFieldSet(this, _edgeCount, (_this$edgeCount3 = _classPrivateFieldGet(this, _edgeCount), _this$edgeCount4 = _this$edgeCount3--, _this$edgeCount3)), _this$edgeCount4;
+    var e = edgeArgsToId(this.#isDirected, v, w, name);
+    if (this.#edgeLabels.hasOwnProperty(e)) {
+      if (valueSpecified) {
+        this.#edgeLabels[e] = value;
       }
       return this;
     }
-
-    /**
-     * Return all edges that point to the node v. Optionally filters those edges down to just those
-     * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
-     * Complexity: O(|E|).
-     */
-  }, {
-    key: "inEdges",
-    value: function inEdges(v, u) {
-      var inV = _classPrivateFieldGet(this, _in)[v];
-      if (inV) {
-        var edges = Object.values(inV);
-        if (!u) {
-          return edges;
-        }
-        return edges.filter(function (edge) {
-          return edge.v === u;
-        });
-      }
+    if (name !== undefined && !this.#isMultigraph) {
+      throw new Error("Cannot set a named edge when isMultigraph = false");
     }
 
-    /**
-     * Return all edges that are pointed at by node v. Optionally filters those edges down to just
-     * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
-     * Complexity: O(|E|).
-     */
-  }, {
-    key: "outEdges",
-    value: function outEdges(v, w) {
-      var outV = _classPrivateFieldGet(this, _out)[v];
-      if (outV) {
-        var edges = Object.values(outV);
-        if (!w) {
-          return edges;
-        }
-        return edges.filter(function (edge) {
-          return edge.w === w;
-        });
-      }
-    }
+    // It didn't exist, so we need to create it.
+    // First ensure the nodes exist.
+    this.setNode(v);
+    this.setNode(w);
+    this.#edgeLabels[e] = valueSpecified ? value : this.#defaultEdgeLabelFn(v, w, name);
+    var edgeObj = edgeArgsToObj(this.#isDirected, v, w, name);
+    // Ensure we add undirected edges in a consistent way.
+    v = edgeObj.v;
+    w = edgeObj.w;
+    Object.freeze(edgeObj);
+    this.#edgeObjs[e] = edgeObj;
+    incrementOrInitEntry(this.#preds[w], v);
+    incrementOrInitEntry(this.#sucs[v], w);
+    this.#in[w][e] = edgeObj;
+    this.#out[v][e] = edgeObj;
+    this.#edgeCount++;
+    return this;
+  }
 
-    /**
-     * Returns all edges to or from node v regardless of direction. Optionally filters those edges
-     * down to just those between nodes v and w regardless of direction.
-     * Complexity: O(|E|).
-     */
-  }, {
-    key: "nodeEdges",
-    value: function nodeEdges(v, w) {
-      var inEdges = this.inEdges(v, w);
-      if (inEdges) {
-        return inEdges.concat(this.outEdges(v, w));
-      }
+  /**
+   * Gets the label for the specified edge.
+   * Complexity: O(1).
+   */
+  edge(v, w, name) {
+    var e = arguments.length === 1 ? edgeObjToId(this.#isDirected, arguments[0]) : edgeArgsToId(this.#isDirected, v, w, name);
+    return this.#edgeLabels[e];
+  }
+
+  /**
+   * Gets the label for the specified edge and converts it to an object.
+   * Complexity: O(1)
+   */
+  edgeAsObj() {
+    const edge = this.edge(...arguments);
+    if (typeof edge !== "object") {
+      return {
+        label: edge
+      };
     }
-  }]);
-  return Graph;
-}();
-function _removeFromParentsChildList2(v) {
-  delete _classPrivateFieldGet(this, _children)[_classPrivateFieldGet(this, _parent)[v]][v];
+    return edge;
+  }
+
+  /**
+   * Detects whether the graph contains specified edge or not. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  hasEdge(v, w, name) {
+    var e = arguments.length === 1 ? edgeObjToId(this.#isDirected, arguments[0]) : edgeArgsToId(this.#isDirected, v, w, name);
+    return this.#edgeLabels.hasOwnProperty(e);
+  }
+
+  /**
+   * Removes the specified edge from the graph. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  removeEdge(v, w, name) {
+    var e = arguments.length === 1 ? edgeObjToId(this.#isDirected, arguments[0]) : edgeArgsToId(this.#isDirected, v, w, name);
+    var edge = this.#edgeObjs[e];
+    if (edge) {
+      v = edge.v;
+      w = edge.w;
+      delete this.#edgeLabels[e];
+      delete this.#edgeObjs[e];
+      decrementOrRemoveEntry(this.#preds[w], v);
+      decrementOrRemoveEntry(this.#sucs[v], w);
+      delete this.#in[w][e];
+      delete this.#out[v][e];
+      this.#edgeCount--;
+    }
+    return this;
+  }
+
+  /**
+   * Return all edges that point to the node v. Optionally filters those edges down to just those
+   * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  inEdges(v, u) {
+    var inV = this.#in[v];
+    if (inV) {
+      var edges = Object.values(inV);
+      if (!u) {
+        return edges;
+      }
+      return edges.filter(edge => edge.v === u);
+    }
+  }
+
+  /**
+   * Return all edges that are pointed at by node v. Optionally filters those edges down to just
+   * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  outEdges(v, w) {
+    var outV = this.#out[v];
+    if (outV) {
+      var edges = Object.values(outV);
+      if (!w) {
+        return edges;
+      }
+      return edges.filter(edge => edge.w === w);
+    }
+  }
+
+  /**
+   * Returns all edges to or from node v regardless of direction. Optionally filters those edges
+   * down to just those between nodes v and w regardless of direction.
+   * Complexity: O(|E|).
+   */
+  nodeEdges(v, w) {
+    var inEdges = this.inEdges(v, w);
+    if (inEdges) {
+      return inEdges.concat(this.outEdges(v, w));
+    }
+  }
 }
+exports.default = Graph;
 function incrementOrInitEntry(map, k) {
   if (map[k]) {
     map[k]++;
@@ -851,3 +663,4 @@ function edgeArgsToObj(isDirected, v_, w_, name) {
 function edgeObjToId(isDirected, edgeObj) {
   return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
 }
+module.exports = exports.default;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,3 @@
 // Includes only the "core" of graphlib
-module.exports = {
-  Graph: require("./graph"),
-  version: require("./version")
-};
+export {default as Graph} from "./graph.js";
+export {default as version} from "./version.js";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,19 @@
 "use strict";
 
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 Object.defineProperty(exports, "Graph", {
   enumerable: true,
-  get: function get() {
-    return _graph["default"];
+  get: function () {
+    return _graph.default;
   }
 });
 exports.json = exports.alg = void 0;
 Object.defineProperty(exports, "version", {
   enumerable: true,
-  get: function get() {
-    return _version["default"];
+  get: function () {
+    return _version.default;
   }
 });
 var _graph = _interopRequireDefault(require("./graph.js"));
@@ -23,6 +22,6 @@ var _json = _interopRequireWildcard(require("./json.js"));
 exports.json = _json;
 var _alg = _interopRequireWildcard(require("./alg/index.js"));
 exports.alg = _alg;
-function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
-function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && Object.prototype.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function (e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != typeof e && "function" != typeof e) return { default: e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && Object.prototype.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n.default = e, t && t.set(e, n), n; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,28 @@
-// Includes only the "core" of graphlib
-export {default as Graph} from "./graph.js";
-export {default as version} from "./version.js";
-export * as json from "./json.js";
-export * as alg from "./alg/index.js";
+"use strict";
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "Graph", {
+  enumerable: true,
+  get: function get() {
+    return _graph["default"];
+  }
+});
+exports.json = exports.alg = void 0;
+Object.defineProperty(exports, "version", {
+  enumerable: true,
+  get: function get() {
+    return _version["default"];
+  }
+});
+var _graph = _interopRequireDefault(require("./graph.js"));
+var _version = _interopRequireDefault(require("./version.js"));
+var _json = _interopRequireWildcard(require("./json.js"));
+exports.json = _json;
+var _alg = _interopRequireWildcard(require("./alg/index.js"));
+exports.alg = _alg;
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && Object.prototype.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
 // Includes only the "core" of graphlib
 export {default as Graph} from "./graph.js";
 export {default as version} from "./version.js";
+export * as json from "./json.js";
+export * as alg from "./alg/index.js";

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,4 +1,4 @@
-import default as Graph from "./graph.js";
+import { default as Graph } from "./graph.js";
 
 /**
  * Creates a JSON representation of the graph that can be serialized to a string with

--- a/lib/json.js
+++ b/lib/json.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.read = read;
 exports.write = write;
 var _graph = _interopRequireDefault(require("./graph.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 /**
  * Creates a JSON representation of the graph that can be serialized to a string with
  * JSON.stringify. The graph can later be restored using json.read.
@@ -70,7 +70,7 @@ function writeEdges(g) {
  * // [ { v: 'a', w: 'b' } ]
  */
 function read(json) {
-  var g = new _graph["default"](json.options).setGraph(json.value);
+  var g = new _graph.default(json.options).setGraph(json.value);
   json.nodes.forEach(function (entry) {
     g.setNode(entry.v, entry.value);
     if (entry.parent) {

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,15 +1,10 @@
-var Graph = require("./graph");
-
-module.exports = {
-  write: write,
-  read: read
-};
+import default as Graph from "./graph.js";
 
 /**
  * Creates a JSON representation of the graph that can be serialized to a string with
  * JSON.stringify. The graph can later be restored using json.read.
  */
-function write(g) {
+export function write(g) {
   var json = {
     options: {
       directed: g.isDirected(),
@@ -65,7 +60,7 @@ function writeEdges(g) {
  * g2.edges()
  * // [ { v: 'a', w: 'b' } ]
  */
-function read(json) {
+export function read(json) {
   var g = new Graph(json.options).setGraph(json.value);
   json.nodes.forEach(function(entry) {
     g.setNode(entry.v, entry.value);

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,2 @@
-module.exports = '2.1.14-pre';
+const version = '2.1.14-pre';
+export { version as default };

--- a/lib/version.js
+++ b/lib/version.js
@@ -3,5 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
-var version = exports["default"] = '2.1.14-pre';
+exports.default = void 0;
+const version = '2.1.14-pre';
+var _default = exports.default = version;
+module.exports = exports.default;

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,2 +1,7 @@
-const version = '2.1.14-pre';
-export { version as default };
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var version = exports["default"] = '2.1.14-pre';

--- a/lib/version.js
+++ b/lib/version.js
@@ -4,6 +4,5 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-const version = '2.1.14-pre';
-var _default = exports.default = version;
+var _default = exports.default = '2.1.14-pre';
 module.exports = exports.default;

--- a/mjs-lib/alg/components.js
+++ b/mjs-lib/alg/components.js
@@ -1,13 +1,8 @@
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = components;
-function components(g) {
+export default function components(g) {
   var visited = {};
   var cmpts = [];
   var cmpt;
+
   function dfs(v) {
     if (visited.hasOwnProperty(v)) return;
     visited[v] = true;
@@ -15,12 +10,14 @@ function components(g) {
     g.successors(v).forEach(dfs);
     g.predecessors(v).forEach(dfs);
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     cmpt = [];
     dfs(v);
     if (cmpt.length) {
       cmpts.push(cmpt);
     }
   });
+
   return cmpts;
 }

--- a/mjs-lib/alg/dfs.js
+++ b/mjs-lib/alg/dfs.js
@@ -1,9 +1,3 @@
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = dfs;
 /*
  * A helper that preforms a pre- or post-order traversal on the input graph
  * and returns the nodes in the order they were visited. If the graph is
@@ -12,26 +6,27 @@ exports["default"] = dfs;
  *
  * If the order is not "post", it will be treated as "pre".
  */
-function dfs(g, vs, order) {
+export default function dfs(g, vs, order) {
   if (!Array.isArray(vs)) {
     vs = [vs];
   }
-  var navigation = g.isDirected() ? function (v) {
-    return g.successors(v);
-  } : function (v) {
-    return g.neighbors(v);
-  };
+
+  var navigation = g.isDirected() ? v => g.successors(v) : v => g.neighbors(v);
   var orderFunc = order === "post" ? postOrderDfs : preOrderDfs;
+
   var acc = [];
   var visited = {};
-  vs.forEach(function (v) {
+  vs.forEach(v => {
     if (!g.hasNode(v)) {
       throw new Error("Graph does not have node: " + v);
     }
+
     orderFunc(v, navigation, visited, acc);
   });
+
   return acc;
 }
+
 function postOrderDfs(v, navigation, visited, acc) {
   var stack = [[v, false]];
   while (stack.length > 0) {
@@ -42,13 +37,12 @@ function postOrderDfs(v, navigation, visited, acc) {
       if (!visited.hasOwnProperty(curr[0])) {
         visited[curr[0]] = true;
         stack.push([curr[0], true]);
-        forEachRight(navigation(curr[0]), function (w) {
-          return stack.push([w, false]);
-        });
+        forEachRight(navigation(curr[0]), w => stack.push([w, false]));
       }
     }
   }
 }
+
 function preOrderDfs(v, navigation, visited, acc) {
   var stack = [v];
   while (stack.length > 0) {
@@ -56,16 +50,16 @@ function preOrderDfs(v, navigation, visited, acc) {
     if (!visited.hasOwnProperty(curr)) {
       visited[curr] = true;
       acc.push(curr);
-      forEachRight(navigation(curr), function (w) {
-        return stack.push(w);
-      });
+      forEachRight(navigation(curr), w => stack.push(w));
     }
   }
 }
+
 function forEachRight(array, iteratee) {
   var length = array.length;
   while (length--) {
     iteratee(array[length], length, array);
   }
+
   return array;
 }

--- a/mjs-lib/alg/dijkstra-all.js
+++ b/mjs-lib/alg/dijkstra-all.js
@@ -1,0 +1,9 @@
+import { default as dijkstra } from "./dijkstra.js";
+
+
+export default function dijkstraAll(g, weightFunc, edgeFunc) {
+  return g.nodes().reduce(function(acc, v) {
+    acc[v] = dijkstra(g, v, weightFunc, edgeFunc);
+    return acc;
+  }, {});
+}

--- a/mjs-lib/alg/dijkstra.js
+++ b/mjs-lib/alg/dijkstra.js
@@ -1,0 +1,52 @@
+import { default as PriorityQueue } from "../data/priority-queue.js";
+
+
+var DEFAULT_WEIGHT_FUNC = () => 1;
+
+export default function dijkstra(g, source, weightFn, edgeFn) {
+  return runDijkstra(g, String(source),
+    weightFn || DEFAULT_WEIGHT_FUNC,
+    edgeFn || function(v) { return g.outEdges(v); });
+}
+
+function runDijkstra(g, source, weightFn, edgeFn) {
+  var results = {};
+  var pq = new PriorityQueue();
+  var v, vEntry;
+
+  var updateNeighbors = function(edge) {
+    var w = edge.v !== v ? edge.v : edge.w;
+    var wEntry = results[w];
+    var weight = weightFn(edge);
+    var distance = vEntry.distance + weight;
+
+    if (weight < 0) {
+      throw new Error("dijkstra does not allow negative edge weights. " +
+                      "Bad edge: " + edge + " Weight: " + weight);
+    }
+
+    if (distance < wEntry.distance) {
+      wEntry.distance = distance;
+      wEntry.predecessor = v;
+      pq.decrease(w, distance);
+    }
+  };
+
+  g.nodes().forEach(function(v) {
+    var distance = v === source ? 0 : Number.POSITIVE_INFINITY;
+    results[v] = { distance: distance };
+    pq.add(v, distance);
+  });
+
+  while (pq.size() > 0) {
+    v = pq.removeMin();
+    vEntry = results[v];
+    if (vEntry.distance === Number.POSITIVE_INFINITY) {
+      break;
+    }
+
+    edgeFn(v).forEach(updateNeighbors);
+  }
+
+  return results;
+}

--- a/mjs-lib/alg/find-cycles.js
+++ b/mjs-lib/alg/find-cycles.js
@@ -1,0 +1,7 @@
+import { default as tarjan } from "./tarjan.js";
+
+export default function findCycles(g) {
+  return tarjan(g).filter(function(cmpt) {
+    return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));
+  });
+}

--- a/mjs-lib/alg/floyd-warshall.js
+++ b/mjs-lib/alg/floyd-warshall.js
@@ -1,0 +1,46 @@
+var DEFAULT_WEIGHT_FUNC = () => 1;
+
+export default function floydWarshall(g, weightFn, edgeFn) {
+  return runFloydWarshall(g,
+    weightFn || DEFAULT_WEIGHT_FUNC,
+    edgeFn || function(v) { return g.outEdges(v); });
+}
+
+function runFloydWarshall(g, weightFn, edgeFn) {
+  var results = {};
+  var nodes = g.nodes();
+
+  nodes.forEach(function(v) {
+    results[v] = {};
+    results[v][v] = { distance: 0 };
+    nodes.forEach(function(w) {
+      if (v !== w) {
+        results[v][w] = { distance: Number.POSITIVE_INFINITY };
+      }
+    });
+    edgeFn(v).forEach(function(edge) {
+      var w = edge.v === v ? edge.w : edge.v;
+      var d = weightFn(edge);
+      results[v][w] = { distance: d, predecessor: v };
+    });
+  });
+
+  nodes.forEach(function(k) {
+    var rowK = results[k];
+    nodes.forEach(function(i) {
+      var rowI = results[i];
+      nodes.forEach(function(j) {
+        var ik = rowI[k];
+        var kj = rowK[j];
+        var ij = rowI[j];
+        var altDistance = ik.distance + kj.distance;
+        if (altDistance < ij.distance) {
+          ij.distance = altDistance;
+          ij.predecessor = kj.predecessor;
+        }
+      });
+    });
+  });
+
+  return results;
+}

--- a/mjs-lib/alg/index.js
+++ b/mjs-lib/alg/index.js
@@ -1,0 +1,11 @@
+export { default as components } from "./components.js";
+export { default as dijkstra } from "./dijkstra.js";
+export { default as dijkstraAll } from "./dijkstra-all.js";
+export { default as findCycles } from "./find-cycles.js";
+export { default as floydWarshall } from "./floyd-warshall.js";
+export { default as isAcyclic } from "./is-acyclic.js";
+export { default as postorder } from "./postorder.js";
+export { default as preorder } from "./preorder.js";
+export { default as prim } from "./prim.js";
+export { default as tarjan } from "./tarjan.js";
+export { default as topsort } from "./topsort.js";

--- a/mjs-lib/alg/is-acyclic.js
+++ b/mjs-lib/alg/is-acyclic.js
@@ -1,0 +1,13 @@
+import { default as topsort } from "./topsort.js";
+
+export default function isAcyclic(g) {
+  try {
+    topsort(g);
+  } catch (e) {
+    if (e instanceof topsort.CycleException) {
+      return false;
+    }
+    throw e;
+  }
+  return true;
+}

--- a/mjs-lib/alg/postorder.js
+++ b/mjs-lib/alg/postorder.js
@@ -1,0 +1,5 @@
+import { default as dfs } from "./dfs.js";
+
+export default function postorder(g, vs) {
+  return dfs(g, vs, "post");
+}

--- a/mjs-lib/alg/preorder.js
+++ b/mjs-lib/alg/preorder.js
@@ -1,0 +1,5 @@
+import { default as dfs } from "./dfs.js";
+
+export default function preorder(g, vs) {
+  return dfs(g, vs, "pre");
+}

--- a/mjs-lib/alg/prim.js
+++ b/mjs-lib/alg/prim.js
@@ -1,17 +1,12 @@
-"use strict";
+import { default as Graph } from "../graph.js";
+import { default as PriorityQueue } from "../data/priority-queue.js";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = prim;
-var _graph = _interopRequireDefault(require("../graph.js"));
-var _priorityQueue = _interopRequireDefault(require("../data/priority-queue.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-function prim(g, weightFunc) {
-  var result = new _graph["default"]();
+export default function prim(g, weightFunc) {
+  var result = new Graph();
   var parents = {};
-  var pq = new _priorityQueue["default"]();
+  var pq = new PriorityQueue();
   var v;
+
   function updateNeighbors(edge) {
     var w = edge.v === v ? edge.w : edge.v;
     var pri = pq.priority(w);
@@ -23,16 +18,19 @@ function prim(g, weightFunc) {
       }
     }
   }
+
   if (g.nodeCount() === 0) {
     return result;
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     pq.add(v, Number.POSITIVE_INFINITY);
     result.setNode(v);
   });
 
   // Start from an arbitrary node
   pq.decrease(g.nodes()[0], 0);
+
   var init = false;
   while (pq.size() > 0) {
     v = pq.removeMin();
@@ -43,7 +41,9 @@ function prim(g, weightFunc) {
     } else {
       init = true;
     }
+
     g.nodeEdges(v).forEach(updateNeighbors);
   }
+
   return result;
 }

--- a/mjs-lib/alg/tarjan.js
+++ b/mjs-lib/alg/tarjan.js
@@ -1,14 +1,9 @@
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = tarjan;
-function tarjan(g) {
+export default function tarjan(g) {
   var index = 0;
   var stack = [];
   var visited = {}; // node id -> { onStack, lowlink, index }
   var results = [];
+
   function dfs(v) {
     var entry = visited[v] = {
       onStack: true,
@@ -16,7 +11,8 @@ function tarjan(g) {
       index: index++
     };
     stack.push(v);
-    g.successors(v).forEach(function (w) {
+
+    g.successors(v).forEach(function(w) {
       if (!visited.hasOwnProperty(w)) {
         dfs(w);
         entry.lowlink = Math.min(entry.lowlink, visited[w].lowlink);
@@ -24,6 +20,7 @@ function tarjan(g) {
         entry.lowlink = Math.min(entry.lowlink, visited[w].index);
       }
     });
+
     if (entry.lowlink === entry.index) {
       var cmpt = [];
       var w;
@@ -35,10 +32,12 @@ function tarjan(g) {
       results.push(cmpt);
     }
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     if (!visited.hasOwnProperty(v)) {
       dfs(v);
     }
   });
+
   return results;
 }

--- a/mjs-lib/alg/topsort.js
+++ b/mjs-lib/alg/topsort.js
@@ -1,0 +1,35 @@
+export default function topsort(g) {
+  var visited = {};
+  var stack = {};
+  var results = [];
+
+  function visit(node) {
+    if (stack.hasOwnProperty(node)) {
+      throw new CycleException();
+    }
+
+    if (!visited.hasOwnProperty(node)) {
+      stack[node] = true;
+      visited[node] = true;
+      g.predecessors(node).forEach(visit);
+      delete stack[node];
+      results.push(node);
+    }
+  }
+
+  g.sinks().forEach(visit);
+
+  if (Object.keys(visited).length !== g.nodeCount()) {
+    throw new CycleException();
+  }
+
+  return results;
+}
+
+class CycleException extends Error {
+  constructor() {
+    super(...arguments);
+  }
+}
+
+topsort.CycleException = CycleException;

--- a/mjs-lib/data/priority-queue.js
+++ b/mjs-lib/data/priority-queue.js
@@ -1,0 +1,148 @@
+/**
+ * A min-priority queue data structure. This algorithm is derived from Cormen,
+ * et al., "Introduction to Algorithms". The basic idea of a min-priority
+ * queue is that you can efficiently (in O(1) time) get the smallest key in
+ * the queue. Adding and removing elements takes O(log n) time. A key can
+ * have its priority decreased in O(log n) time.
+ */
+export default class PriorityQueue {
+  #arr = [];
+  #keyIndices = {};
+
+  /**
+   * Returns the number of elements in the queue. Takes `O(1)` time.
+   */
+  size() {
+    return this.#arr.length;
+  }
+
+  /**
+   * Returns the keys that are in the queue. Takes `O(n)` time.
+   */
+  keys() {
+    return this.#arr.map(function(x) { return x.key; });
+  }
+
+  /**
+   * Returns `true` if **key** is in the queue and `false` if not.
+   */
+  has(key) {
+    return this.#keyIndices.hasOwnProperty(key);
+  }
+
+  /**
+   * Returns the priority for **key**. If **key** is not present in the queue
+   * then this function returns `undefined`. Takes `O(1)` time.
+   *
+   * @param {Object} key
+   */
+  priority(key) {
+    var index = this.#keyIndices[key];
+    if (index !== undefined) {
+      return this.#arr[index].priority;
+    }
+  }
+
+  /**
+   * Returns the key for the minimum element in this queue. If the queue is
+   * empty this function throws an Error. Takes `O(1)` time.
+   */
+  min() {
+    if (this.size() === 0) {
+      throw new Error("Queue underflow");
+    }
+    return this.#arr[0].key;
+  }
+
+  /**
+   * Inserts a new key into the priority queue. If the key already exists in
+   * the queue this function returns `false`; otherwise it will return `true`.
+   * Takes `O(n)` time.
+   *
+   * @param {Object} key the key to add
+   * @param {Number} priority the initial priority for the key
+   */
+  add(key, priority) {
+    var keyIndices = this.#keyIndices;
+    key = String(key);
+    if (!keyIndices.hasOwnProperty(key)) {
+      var arr = this.#arr;
+      var index = arr.length;
+      keyIndices[key] = index;
+      arr.push({key: key, priority: priority});
+      this.#decrease(index);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
+   */
+  removeMin() {
+    this.#swap(0, this.#arr.length - 1);
+    var min = this.#arr.pop();
+    delete this.#keyIndices[min.key];
+    this.#heapify(0);
+    return min.key;
+  }
+
+  /**
+   * Decreases the priority for **key** to **priority**. If the new priority is
+   * greater than the previous priority, this function will throw an Error.
+   *
+   * @param {Object} key the key for which to raise priority
+   * @param {Number} priority the new priority for the key
+   */
+  decrease(key, priority) {
+    var index = this.#keyIndices[key];
+    if (priority > this.#arr[index].priority) {
+      throw new Error("New priority is greater than current priority. " +
+          "Key: " + key + " Old: " + this.#arr[index].priority + " New: " + priority);
+    }
+    this.#arr[index].priority = priority;
+    this.#decrease(index);
+  }
+
+  #heapify(i) {
+    var arr = this.#arr;
+    var l = 2 * i;
+    var r = l + 1;
+    var largest = i;
+    if (l < arr.length) {
+      largest = arr[l].priority < arr[largest].priority ? l : largest;
+      if (r < arr.length) {
+        largest = arr[r].priority < arr[largest].priority ? r : largest;
+      }
+      if (largest !== i) {
+        this.#swap(i, largest);
+        this.#heapify(largest);
+      }
+    }
+  }
+
+  #decrease(index) {
+    var arr = this.#arr;
+    var priority = arr[index].priority;
+    var parent;
+    while (index !== 0) {
+      parent = index >> 1;
+      if (arr[parent].priority < priority) {
+        break;
+      }
+      this.#swap(index, parent);
+      index = parent;
+    }
+  }
+
+  #swap(i, j) {
+    var arr = this.#arr;
+    var keyIndices = this.#keyIndices;
+    var origArrI = arr[i];
+    var origArrJ = arr[j];
+    arr[i] = origArrJ;
+    arr[j] = origArrI;
+    keyIndices[origArrJ.key] = i;
+    keyIndices[origArrI.key] = j;
+  }
+}

--- a/mjs-lib/graph.js
+++ b/mjs-lib/graph.js
@@ -1,0 +1,694 @@
+"use strict";
+
+var DEFAULT_EDGE_NAME = "\x00";
+var GRAPH_NODE = "\x00";
+var EDGE_KEY_DELIM = "\x01";
+
+// Implementation notes:
+//
+//  * Node id query functions should return string ids for the nodes
+//  * Edge id query functions should return an "edgeObj", edge object, that is
+//    composed of enough information to uniquely identify an edge: {v, w, name}.
+//  * Internally we use an "edgeId", a stringified form of the edgeObj, to
+//    reference edges. This is because we need a performant way to look these
+//    edges up and, object properties, which have string keys, are the closest
+//    we're going to get to a performant hashtable in JavaScript.
+
+export default class Graph {
+  #isDirected = true;
+  #isMultigraph = false;
+  #isCompound = false;
+
+  // Label for the graph itself
+  #label;
+
+  // Defaults to be set when creating a new node
+  #defaultNodeLabelFn = () => undefined;
+
+  // Defaults to be set when creating a new edge
+  #defaultEdgeLabelFn = () => undefined;
+
+  // v -> label
+  #nodes = {};
+
+  // v -> edgeObj
+  #in = {};
+
+  // u -> v -> Number
+  #preds = {};
+
+  // v -> edgeObj
+  #out = {};
+
+  // v -> w -> Number
+  #sucs = {};
+
+  // e -> edgeObj
+  #edgeObjs = {};
+
+  // e -> label
+  #edgeLabels = {};
+
+  /* Number of nodes in the graph. Should only be changed by the implementation. */
+  #nodeCount = 0;
+
+  /* Number of edges in the graph. Should only be changed by the implementation. */
+  #edgeCount = 0;
+
+  #parent;
+
+  #children;
+
+  constructor(opts) {
+    if (opts) {
+      this.#isDirected = opts.hasOwnProperty("directed") ? opts.directed : true;
+      this.#isMultigraph = opts.hasOwnProperty("multigraph") ? opts.multigraph : false;
+      this.#isCompound = opts.hasOwnProperty("compound") ? opts.compound : false;
+    }
+
+    if (this.#isCompound) {
+      // v -> parent
+      this.#parent = {};
+
+      // v -> children
+      this.#children = {};
+      this.#children[GRAPH_NODE] = {};
+    }
+  }
+
+  /* === Graph functions ========= */
+
+  /**
+   * Whether graph was created with 'directed' flag set to true or not.
+   */
+  isDirected() {
+    return this.#isDirected;
+  }
+
+  /**
+   * Whether graph was created with 'multigraph' flag set to true or not.
+   */
+  isMultigraph() {
+    return this.#isMultigraph;
+  }
+
+  /**
+   * Whether graph was created with 'compound' flag set to true or not.
+   */
+  isCompound() {
+    return this.#isCompound;
+  }
+
+  /**
+   * Sets the label of the graph.
+   */
+  setGraph(label) {
+    this.#label = label;
+    return this;
+  }
+
+  /**
+   * Gets the graph label.
+   */
+  graph() {
+    return this.#label;
+  }
+
+
+  /* === Node functions ========== */
+
+  /**
+   * Sets the default node label. If newDefault is a function, it will be
+   * invoked ach time when setting a label for a node. Otherwise, this label
+   * will be assigned as default label in case if no label was specified while
+   * setting a node.
+   * Complexity: O(1).
+   */
+  setDefaultNodeLabel(newDefault) {
+    this.#defaultNodeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultNodeLabelFn = () => newDefault;
+    }
+
+    return this;
+  }
+
+  /**
+   * Gets the number of nodes in the graph.
+   * Complexity: O(1).
+   */
+  nodeCount() {
+    return this.#nodeCount;
+  }
+
+  /**
+   * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
+   * not included in list.
+   * Complexity: O(1).
+   */
+  nodes() {
+    return Object.keys(this.#nodes);
+  }
+
+  /**
+   * Gets list of nodes without in-edges.
+   * Complexity: O(|V|).
+   */
+  sources() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#in[v]).length === 0);
+  }
+
+  /**
+   * Gets list of nodes without out-edges.
+   * Complexity: O(|V|).
+   */
+  sinks() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#out[v]).length === 0);
+  }
+
+  /**
+   * Invokes setNode method for each node in names list.
+   * Complexity: O(|names|).
+   */
+  setNodes(vs, value) {
+    var args = arguments;
+    var self = this;
+    vs.forEach(function(v) {
+      if (args.length > 1) {
+        self.setNode(v, value);
+      } else {
+        self.setNode(v);
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Creates or updates the value for the node v in the graph. If label is supplied
+   * it is set as the value for the node. If label is not supplied and the node was
+   * created by this call then the default node label will be assigned.
+   * Complexity: O(1).
+   */
+  setNode(v, value) {
+    if (this.#nodes.hasOwnProperty(v)) {
+      if (arguments.length > 1) {
+        this.#nodes[v] = value;
+      }
+      return this;
+    }
+
+    this.#nodes[v] = arguments.length > 1 ? value : this.#defaultNodeLabelFn(v);
+    if (this.#isCompound) {
+      this.#parent[v] = GRAPH_NODE;
+      this.#children[v] = {};
+      this.#children[GRAPH_NODE][v] = true;
+    }
+    this.#in[v] = {};
+    this.#preds[v] = {};
+    this.#out[v] = {};
+    this.#sucs[v] = {};
+    ++this.#nodeCount;
+    return this;
+  }
+
+  /**
+   * Gets the label of node with specified name.
+   * Complexity: O(|V|).
+   */
+  node(v) {
+    return this.#nodes[v];
+  }
+
+  /**
+   * Detects whether graph has a node with specified name or not.
+   */
+  hasNode(v) {
+    return this.#nodes.hasOwnProperty(v);
+  }
+
+  /**
+   * Remove the node with the name from the graph or do nothing if the node is not in
+   * the graph. If the node was removed this function also removes any incident
+   * edges.
+   * Complexity: O(1).
+   */
+  removeNode(v) {
+    var self = this;
+    if (this.#nodes.hasOwnProperty(v)) {
+      var removeEdge = e => self.removeEdge(self.#edgeObjs[e]);
+      delete this.#nodes[v];
+      if (this.#isCompound) {
+        this.#removeFromParentsChildList(v);
+        delete this.#parent[v];
+        this.children(v).forEach(function(child) {
+          self.setParent(child);
+        });
+        delete this.#children[v];
+      }
+      Object.keys(this.#in[v]).forEach(removeEdge);
+      delete this.#in[v];
+      delete this.#preds[v];
+      Object.keys(this.#out[v]).forEach(removeEdge);
+      delete this.#out[v];
+      delete this.#sucs[v];
+      --this.#nodeCount;
+    }
+    return this;
+  }
+
+  /**
+   * Sets node p as a parent for node v if it is defined, or removes the
+   * parent for v if p is undefined. Method throws an exception in case of
+   * invoking it in context of noncompound graph.
+   * Average-case complexity: O(1).
+   */
+  setParent(v, parent) {
+    if (!this.#isCompound) {
+      throw new Error("Cannot set parent in a non-compound graph");
+    }
+
+    if (parent === undefined) {
+      parent = GRAPH_NODE;
+    } else {
+      // Coerce parent to string
+      parent += "";
+      for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
+        if (ancestor === v) {
+          throw new Error("Setting " + parent+ " as parent of " + v +
+              " would create a cycle");
+        }
+      }
+
+      this.setNode(parent);
+    }
+
+    this.setNode(v);
+    this.#removeFromParentsChildList(v);
+    this.#parent[v] = parent;
+    this.#children[parent][v] = true;
+    return this;
+  }
+
+  #removeFromParentsChildList(v) {
+    delete this.#children[this.#parent[v]][v];
+  }
+
+  /**
+   * Gets parent node for node v.
+   * Complexity: O(1).
+   */
+  parent(v) {
+    if (this.#isCompound) {
+      var parent = this.#parent[v];
+      if (parent !== GRAPH_NODE) {
+        return parent;
+      }
+    }
+  }
+
+  /**
+   * Gets list of direct children of node v.
+   * Complexity: O(1).
+   */
+  children(v = GRAPH_NODE) {
+    if (this.#isCompound) {
+      var children = this.#children[v];
+      if (children) {
+        return Object.keys(children);
+      }
+    } else if (v === GRAPH_NODE) {
+      return this.nodes();
+    } else if (this.hasNode(v)) {
+      return [];
+    }
+  }
+
+  /**
+   * Return all nodes that are predecessors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  predecessors(v) {
+    var predsV = this.#preds[v];
+    if (predsV) {
+      return Object.keys(predsV);
+    }
+  }
+
+  /**
+   * Return all nodes that are successors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  successors(v) {
+    var sucsV = this.#sucs[v];
+    if (sucsV) {
+      return Object.keys(sucsV);
+    }
+  }
+
+  /**
+   * Return all nodes that are predecessors or successors of the specified node or undefined if
+   * node v is not in the graph.
+   * Complexity: O(|V|).
+   */
+  neighbors(v) {
+    var preds = this.predecessors(v);
+    if (preds) {
+      const union = new Set(preds);
+      for (var succ of this.successors(v)) {
+        union.add(succ);
+      }
+
+      return Array.from(union.values());
+    }
+  }
+
+  isLeaf(v) {
+    var neighbors;
+    if (this.isDirected()) {
+      neighbors = this.successors(v);
+    } else {
+      neighbors = this.neighbors(v);
+    }
+    return neighbors.length === 0;
+  }
+
+  /**
+   * Creates new graph with nodes filtered via filter. Edges incident to rejected node
+   * are also removed. In case of compound graph, if parent is rejected by filter,
+   * than all its children are rejected too.
+   * Average-case complexity: O(|E|+|V|).
+   */
+  filterNodes(filter) {
+    var copy = new this.constructor({
+      directed: this.#isDirected,
+      multigraph: this.#isMultigraph,
+      compound: this.#isCompound
+    });
+
+    copy.setGraph(this.graph());
+
+    var self = this;
+    Object.entries(this.#nodes).forEach(function([v, value]) {
+      if (filter(v)) {
+        copy.setNode(v, value);
+      }
+    });
+
+    Object.values(this.#edgeObjs).forEach(function(e) {
+      if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
+        copy.setEdge(e, self.edge(e));
+      }
+    });
+
+    var parents = {};
+    function findParent(v) {
+      var parent = self.parent(v);
+      if (parent === undefined || copy.hasNode(parent)) {
+        parents[v] = parent;
+        return parent;
+      } else if (parent in parents) {
+        return parents[parent];
+      } else {
+        return findParent(parent);
+      }
+    }
+
+    if (this.#isCompound) {
+      copy.nodes().forEach(v => copy.setParent(v, findParent(v)));
+    }
+
+    return copy;
+  }
+
+  /* === Edge functions ========== */
+
+  /**
+   * Sets the default edge label or factory function. This label will be
+   * assigned as default label in case if no label was specified while setting
+   * an edge or this function will be invoked each time when setting an edge
+   * with no label specified and returned value * will be used as a label for edge.
+   * Complexity: O(1).
+   */
+  setDefaultEdgeLabel(newDefault) {
+    this.#defaultEdgeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultEdgeLabelFn = () => newDefault;
+    }
+
+    return this;
+  }
+
+  /**
+   * Gets the number of edges in the graph.
+   * Complexity: O(1).
+   */
+  edgeCount() {
+    return this.#edgeCount;
+  }
+
+  /**
+   * Gets edges of the graph. In case of compound graph subgraphs are not considered.
+   * Complexity: O(|E|).
+   */
+  edges() {
+    return Object.values(this.#edgeObjs);
+  }
+
+  /**
+   * Establish an edges path over the nodes in nodes list. If some edge is already
+   * exists, it will update its label, otherwise it will create an edge between pair
+   * of nodes with label provided or default label if no label provided.
+   * Complexity: O(|nodes|).
+   */
+  setPath(vs, value) {
+    var self = this;
+    var args = arguments;
+    vs.reduce(function(v, w) {
+      if (args.length > 1) {
+        self.setEdge(v, w, value);
+      } else {
+        self.setEdge(v, w);
+      }
+      return w;
+    });
+    return this;
+  }
+
+  /**
+   * Creates or updates the label for the edge (v, w) with the optionally supplied
+   * name. If label is supplied it is set as the value for the edge. If label is not
+   * supplied and the edge was created by this call then the default edge label will
+   * be assigned. The name parameter is only useful with multigraphs.
+   */
+  setEdge() {
+    var v, w, name, value;
+    var valueSpecified = false;
+    var arg0 = arguments[0];
+
+    if (typeof arg0 === "object" && arg0 !== null && "v" in arg0) {
+      v = arg0.v;
+      w = arg0.w;
+      name = arg0.name;
+      if (arguments.length === 2) {
+        value = arguments[1];
+        valueSpecified = true;
+      }
+    } else {
+      v = arg0;
+      w = arguments[1];
+      name = arguments[3];
+      if (arguments.length > 2) {
+        value = arguments[2];
+        valueSpecified = true;
+      }
+    }
+
+    v = "" + v;
+    w = "" + w;
+    if (name !== undefined) {
+      name = "" + name;
+    }
+
+    var e = edgeArgsToId(this.#isDirected, v, w, name);
+    if (this.#edgeLabels.hasOwnProperty(e)) {
+      if (valueSpecified) {
+        this.#edgeLabels[e] = value;
+      }
+      return this;
+    }
+
+    if (name !== undefined && !this.#isMultigraph) {
+      throw new Error("Cannot set a named edge when isMultigraph = false");
+    }
+
+    // It didn't exist, so we need to create it.
+    // First ensure the nodes exist.
+    this.setNode(v);
+    this.setNode(w);
+
+    this.#edgeLabels[e] = valueSpecified ? value : this.#defaultEdgeLabelFn(v, w, name);
+
+    var edgeObj = edgeArgsToObj(this.#isDirected, v, w, name);
+    // Ensure we add undirected edges in a consistent way.
+    v = edgeObj.v;
+    w = edgeObj.w;
+
+    Object.freeze(edgeObj);
+    this.#edgeObjs[e] = edgeObj;
+    incrementOrInitEntry(this.#preds[w], v);
+    incrementOrInitEntry(this.#sucs[v], w);
+    this.#in[w][e] = edgeObj;
+    this.#out[v][e] = edgeObj;
+    this.#edgeCount++;
+    return this;
+  }
+
+  /**
+   * Gets the label for the specified edge.
+   * Complexity: O(1).
+   */
+  edge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    return this.#edgeLabels[e];
+  }
+
+  /**
+   * Gets the label for the specified edge and converts it to an object.
+   * Complexity: O(1)
+   */
+  edgeAsObj() {
+    const edge = this.edge(...arguments);
+    if (typeof edge !== "object") {
+      return {label: edge};
+    }
+
+    return edge;
+  }
+
+  /**
+   * Detects whether the graph contains specified edge or not. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  hasEdge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    return this.#edgeLabels.hasOwnProperty(e);
+  }
+
+  /**
+   * Removes the specified edge from the graph. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  removeEdge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    var edge = this.#edgeObjs[e];
+    if (edge) {
+      v = edge.v;
+      w = edge.w;
+      delete this.#edgeLabels[e];
+      delete this.#edgeObjs[e];
+      decrementOrRemoveEntry(this.#preds[w], v);
+      decrementOrRemoveEntry(this.#sucs[v], w);
+      delete this.#in[w][e];
+      delete this.#out[v][e];
+      this.#edgeCount--;
+    }
+    return this;
+  }
+
+  /**
+   * Return all edges that point to the node v. Optionally filters those edges down to just those
+   * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  inEdges(v, u) {
+    var inV = this.#in[v];
+    if (inV) {
+      var edges = Object.values(inV);
+      if (!u) {
+        return edges;
+      }
+      return edges.filter(edge => edge.v === u);
+    }
+  }
+
+  /**
+   * Return all edges that are pointed at by node v. Optionally filters those edges down to just
+   * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  outEdges(v, w) {
+    var outV = this.#out[v];
+    if (outV) {
+      var edges = Object.values(outV);
+      if (!w) {
+        return edges;
+      }
+      return edges.filter(edge => edge.w === w);
+    }
+  }
+
+  /**
+   * Returns all edges to or from node v regardless of direction. Optionally filters those edges
+   * down to just those between nodes v and w regardless of direction.
+   * Complexity: O(|E|).
+   */
+  nodeEdges(v, w) {
+    var inEdges = this.inEdges(v, w);
+    if (inEdges) {
+      return inEdges.concat(this.outEdges(v, w));
+    }
+  }
+}
+
+function incrementOrInitEntry(map, k) {
+  if (map[k]) {
+    map[k]++;
+  } else {
+    map[k] = 1;
+  }
+}
+
+function decrementOrRemoveEntry(map, k) {
+  if (!--map[k]) { delete map[k]; }
+}
+
+function edgeArgsToId(isDirected, v_, w_, name) {
+  var v = "" + v_;
+  var w = "" + w_;
+  if (!isDirected && v > w) {
+    var tmp = v;
+    v = w;
+    w = tmp;
+  }
+  return v + EDGE_KEY_DELIM + w + EDGE_KEY_DELIM +
+             (name === undefined ? DEFAULT_EDGE_NAME : name);
+}
+
+function edgeArgsToObj(isDirected, v_, w_, name) {
+  var v = "" + v_;
+  var w = "" + w_;
+  if (!isDirected && v > w) {
+    var tmp = v;
+    v = w;
+    w = tmp;
+  }
+  var edgeObj =  { v: v, w: w };
+  if (name) {
+    edgeObj.name = name;
+  }
+  return edgeObj;
+}
+
+function edgeObjToId(isDirected, edgeObj) {
+  return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
+}

--- a/mjs-lib/index.js
+++ b/mjs-lib/index.js
@@ -1,0 +1,5 @@
+// Includes only the "core" of graphlib
+export {default as Graph} from "./graph.js";
+export {default as version} from "./version.js";
+export * as json from "./json.js";
+export * as alg from "./alg/index.js";

--- a/mjs-lib/json.js
+++ b/mjs-lib/json.js
@@ -1,17 +1,10 @@
-"use strict";
+import { default as Graph } from "./graph.js";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.read = read;
-exports.write = write;
-var _graph = _interopRequireDefault(require("./graph.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 /**
  * Creates a JSON representation of the graph that can be serialized to a string with
  * JSON.stringify. The graph can later be restored using json.read.
  */
-function write(g) {
+export function write(g) {
   var json = {
     options: {
       directed: g.isDirected(),
@@ -21,18 +14,18 @@ function write(g) {
     nodes: writeNodes(g),
     edges: writeEdges(g)
   };
+
   if (g.graph() !== undefined) {
     json.value = structuredClone(g.graph());
   }
   return json;
 }
+
 function writeNodes(g) {
-  return g.nodes().map(function (v) {
+  return g.nodes().map(function(v) {
     var nodeValue = g.node(v);
     var parent = g.parent(v);
-    var node = {
-      v: v
-    };
+    var node = { v: v };
     if (nodeValue !== undefined) {
       node.value = nodeValue;
     }
@@ -42,13 +35,11 @@ function writeNodes(g) {
     return node;
   });
 }
+
 function writeEdges(g) {
-  return g.edges().map(function (e) {
+  return g.edges().map(function(e) {
     var edgeValue = g.edge(e);
-    var edge = {
-      v: e.v,
-      w: e.w
-    };
+    var edge = { v: e.v, w: e.w };
     if (e.name !== undefined) {
       edge.name = e.name;
     }
@@ -69,20 +60,16 @@ function writeEdges(g) {
  * g2.edges()
  * // [ { v: 'a', w: 'b' } ]
  */
-function read(json) {
-  var g = new _graph["default"](json.options).setGraph(json.value);
-  json.nodes.forEach(function (entry) {
+export function read(json) {
+  var g = new Graph(json.options).setGraph(json.value);
+  json.nodes.forEach(function(entry) {
     g.setNode(entry.v, entry.value);
     if (entry.parent) {
       g.setParent(entry.v, entry.parent);
     }
   });
-  json.edges.forEach(function (entry) {
-    g.setEdge({
-      v: entry.v,
-      w: entry.w,
-      name: entry.name
-    }, entry.value);
+  json.edges.forEach(function(entry) {
+    g.setEdge({ v: entry.v, w: entry.w, name: entry.name }, entry.value);
   });
   return g;
 }

--- a/mjs-lib/version.js
+++ b/mjs-lib/version.js
@@ -1,0 +1,2 @@
+const version = '2.1.14-pre';
+export { version as default };

--- a/mjs-lib/version.js
+++ b/mjs-lib/version.js
@@ -1,2 +1,2 @@
 const version = '2.1.14-pre';
-export { version as default };
+export default version;

--- a/mjs-lib/version.js
+++ b/mjs-lib/version.js
@@ -1,2 +1,1 @@
-const version = '2.1.14-pre';
-export default version;
+export default '2.1.14-pre';

--- a/old-lib/alg/components.js
+++ b/old-lib/alg/components.js
@@ -1,13 +1,10 @@
-"use strict";
+module.exports = components;
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = components;
 function components(g) {
   var visited = {};
   var cmpts = [];
   var cmpt;
+
   function dfs(v) {
     if (visited.hasOwnProperty(v)) return;
     visited[v] = true;
@@ -15,12 +12,14 @@ function components(g) {
     g.successors(v).forEach(dfs);
     g.predecessors(v).forEach(dfs);
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     cmpt = [];
     dfs(v);
     if (cmpt.length) {
       cmpts.push(cmpt);
     }
   });
+
   return cmpts;
 }

--- a/old-lib/alg/dfs.js
+++ b/old-lib/alg/dfs.js
@@ -1,9 +1,5 @@
-"use strict";
+module.exports = dfs;
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = dfs;
 /*
  * A helper that preforms a pre- or post-order traversal on the input graph
  * and returns the nodes in the order they were visited. If the graph is
@@ -16,22 +12,23 @@ function dfs(g, vs, order) {
   if (!Array.isArray(vs)) {
     vs = [vs];
   }
-  var navigation = g.isDirected() ? function (v) {
-    return g.successors(v);
-  } : function (v) {
-    return g.neighbors(v);
-  };
+
+  var navigation = g.isDirected() ? v => g.successors(v) : v => g.neighbors(v);
   var orderFunc = order === "post" ? postOrderDfs : preOrderDfs;
+
   var acc = [];
   var visited = {};
-  vs.forEach(function (v) {
+  vs.forEach(v => {
     if (!g.hasNode(v)) {
       throw new Error("Graph does not have node: " + v);
     }
+
     orderFunc(v, navigation, visited, acc);
   });
+
   return acc;
 }
+
 function postOrderDfs(v, navigation, visited, acc) {
   var stack = [[v, false]];
   while (stack.length > 0) {
@@ -42,13 +39,12 @@ function postOrderDfs(v, navigation, visited, acc) {
       if (!visited.hasOwnProperty(curr[0])) {
         visited[curr[0]] = true;
         stack.push([curr[0], true]);
-        forEachRight(navigation(curr[0]), function (w) {
-          return stack.push([w, false]);
-        });
+        forEachRight(navigation(curr[0]), w => stack.push([w, false]));
       }
     }
   }
 }
+
 function preOrderDfs(v, navigation, visited, acc) {
   var stack = [v];
   while (stack.length > 0) {
@@ -56,16 +52,16 @@ function preOrderDfs(v, navigation, visited, acc) {
     if (!visited.hasOwnProperty(curr)) {
       visited[curr] = true;
       acc.push(curr);
-      forEachRight(navigation(curr), function (w) {
-        return stack.push(w);
-      });
+      forEachRight(navigation(curr), w => stack.push(w));
     }
   }
 }
+
 function forEachRight(array, iteratee) {
   var length = array.length;
   while (length--) {
     iteratee(array[length], length, array);
   }
+
   return array;
 }

--- a/old-lib/alg/dijkstra-all.js
+++ b/old-lib/alg/dijkstra-all.js
@@ -1,0 +1,10 @@
+var dijkstra = require("./dijkstra");
+
+module.exports = dijkstraAll;
+
+function dijkstraAll(g, weightFunc, edgeFunc) {
+  return g.nodes().reduce(function(acc, v) {
+    acc[v] = dijkstra(g, v, weightFunc, edgeFunc);
+    return acc;
+  }, {});
+}

--- a/old-lib/alg/dijkstra.js
+++ b/old-lib/alg/dijkstra.js
@@ -1,0 +1,53 @@
+var PriorityQueue = require("../data/priority-queue");
+
+module.exports = dijkstra;
+
+var DEFAULT_WEIGHT_FUNC = () => 1;
+
+function dijkstra(g, source, weightFn, edgeFn) {
+  return runDijkstra(g, String(source),
+    weightFn || DEFAULT_WEIGHT_FUNC,
+    edgeFn || function(v) { return g.outEdges(v); });
+}
+
+function runDijkstra(g, source, weightFn, edgeFn) {
+  var results = {};
+  var pq = new PriorityQueue();
+  var v, vEntry;
+
+  var updateNeighbors = function(edge) {
+    var w = edge.v !== v ? edge.v : edge.w;
+    var wEntry = results[w];
+    var weight = weightFn(edge);
+    var distance = vEntry.distance + weight;
+
+    if (weight < 0) {
+      throw new Error("dijkstra does not allow negative edge weights. " +
+                      "Bad edge: " + edge + " Weight: " + weight);
+    }
+
+    if (distance < wEntry.distance) {
+      wEntry.distance = distance;
+      wEntry.predecessor = v;
+      pq.decrease(w, distance);
+    }
+  };
+
+  g.nodes().forEach(function(v) {
+    var distance = v === source ? 0 : Number.POSITIVE_INFINITY;
+    results[v] = { distance: distance };
+    pq.add(v, distance);
+  });
+
+  while (pq.size() > 0) {
+    v = pq.removeMin();
+    vEntry = results[v];
+    if (vEntry.distance === Number.POSITIVE_INFINITY) {
+      break;
+    }
+
+    edgeFn(v).forEach(updateNeighbors);
+  }
+
+  return results;
+}

--- a/old-lib/alg/find-cycles.js
+++ b/old-lib/alg/find-cycles.js
@@ -1,0 +1,9 @@
+var tarjan = require("./tarjan");
+
+module.exports = findCycles;
+
+function findCycles(g) {
+  return tarjan(g).filter(function(cmpt) {
+    return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));
+  });
+}

--- a/old-lib/alg/floyd-warshall.js
+++ b/old-lib/alg/floyd-warshall.js
@@ -1,0 +1,48 @@
+module.exports = floydWarshall;
+
+var DEFAULT_WEIGHT_FUNC = () => 1;
+
+function floydWarshall(g, weightFn, edgeFn) {
+  return runFloydWarshall(g,
+    weightFn || DEFAULT_WEIGHT_FUNC,
+    edgeFn || function(v) { return g.outEdges(v); });
+}
+
+function runFloydWarshall(g, weightFn, edgeFn) {
+  var results = {};
+  var nodes = g.nodes();
+
+  nodes.forEach(function(v) {
+    results[v] = {};
+    results[v][v] = { distance: 0 };
+    nodes.forEach(function(w) {
+      if (v !== w) {
+        results[v][w] = { distance: Number.POSITIVE_INFINITY };
+      }
+    });
+    edgeFn(v).forEach(function(edge) {
+      var w = edge.v === v ? edge.w : edge.v;
+      var d = weightFn(edge);
+      results[v][w] = { distance: d, predecessor: v };
+    });
+  });
+
+  nodes.forEach(function(k) {
+    var rowK = results[k];
+    nodes.forEach(function(i) {
+      var rowI = results[i];
+      nodes.forEach(function(j) {
+        var ik = rowI[k];
+        var kj = rowK[j];
+        var ij = rowI[j];
+        var altDistance = ik.distance + kj.distance;
+        if (altDistance < ij.distance) {
+          ij.distance = altDistance;
+          ij.predecessor = kj.predecessor;
+        }
+      });
+    });
+  });
+
+  return results;
+}

--- a/old-lib/alg/index.js
+++ b/old-lib/alg/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  components: require("./components"),
+  dijkstra: require("./dijkstra"),
+  dijkstraAll: require("./dijkstra-all"),
+  findCycles: require("./find-cycles"),
+  floydWarshall: require("./floyd-warshall"),
+  isAcyclic: require("./is-acyclic"),
+  postorder: require("./postorder"),
+  preorder: require("./preorder"),
+  prim: require("./prim"),
+  tarjan: require("./tarjan"),
+  topsort: require("./topsort")
+};

--- a/old-lib/alg/is-acyclic.js
+++ b/old-lib/alg/is-acyclic.js
@@ -1,0 +1,15 @@
+var topsort = require("./topsort");
+
+module.exports = isAcyclic;
+
+function isAcyclic(g) {
+  try {
+    topsort(g);
+  } catch (e) {
+    if (e instanceof topsort.CycleException) {
+      return false;
+    }
+    throw e;
+  }
+  return true;
+}

--- a/old-lib/alg/postorder.js
+++ b/old-lib/alg/postorder.js
@@ -1,0 +1,7 @@
+var dfs = require("./dfs");
+
+module.exports = postorder;
+
+function postorder(g, vs) {
+  return dfs(g, vs, "post");
+}

--- a/old-lib/alg/preorder.js
+++ b/old-lib/alg/preorder.js
@@ -1,0 +1,7 @@
+var dfs = require("./dfs");
+
+module.exports = preorder;
+
+function preorder(g, vs) {
+  return dfs(g, vs, "pre");
+}

--- a/old-lib/alg/prim.js
+++ b/old-lib/alg/prim.js
@@ -1,17 +1,14 @@
-"use strict";
+var Graph = require("../graph");
+var PriorityQueue = require("../data/priority-queue");
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = prim;
-var _graph = _interopRequireDefault(require("../graph.js"));
-var _priorityQueue = _interopRequireDefault(require("../data/priority-queue.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+module.exports = prim;
+
 function prim(g, weightFunc) {
-  var result = new _graph["default"]();
+  var result = new Graph();
   var parents = {};
-  var pq = new _priorityQueue["default"]();
+  var pq = new PriorityQueue();
   var v;
+
   function updateNeighbors(edge) {
     var w = edge.v === v ? edge.w : edge.v;
     var pri = pq.priority(w);
@@ -23,16 +20,19 @@ function prim(g, weightFunc) {
       }
     }
   }
+
   if (g.nodeCount() === 0) {
     return result;
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     pq.add(v, Number.POSITIVE_INFINITY);
     result.setNode(v);
   });
 
   // Start from an arbitrary node
   pq.decrease(g.nodes()[0], 0);
+
   var init = false;
   while (pq.size() > 0) {
     v = pq.removeMin();
@@ -43,7 +43,9 @@ function prim(g, weightFunc) {
     } else {
       init = true;
     }
+
     g.nodeEdges(v).forEach(updateNeighbors);
   }
+
   return result;
 }

--- a/old-lib/alg/tarjan.js
+++ b/old-lib/alg/tarjan.js
@@ -1,14 +1,11 @@
-"use strict";
+module.exports = tarjan;
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = tarjan;
 function tarjan(g) {
   var index = 0;
   var stack = [];
   var visited = {}; // node id -> { onStack, lowlink, index }
   var results = [];
+
   function dfs(v) {
     var entry = visited[v] = {
       onStack: true,
@@ -16,7 +13,8 @@ function tarjan(g) {
       index: index++
     };
     stack.push(v);
-    g.successors(v).forEach(function (w) {
+
+    g.successors(v).forEach(function(w) {
       if (!visited.hasOwnProperty(w)) {
         dfs(w);
         entry.lowlink = Math.min(entry.lowlink, visited[w].lowlink);
@@ -24,6 +22,7 @@ function tarjan(g) {
         entry.lowlink = Math.min(entry.lowlink, visited[w].index);
       }
     });
+
     if (entry.lowlink === entry.index) {
       var cmpt = [];
       var w;
@@ -35,10 +34,12 @@ function tarjan(g) {
       results.push(cmpt);
     }
   }
-  g.nodes().forEach(function (v) {
+
+  g.nodes().forEach(function(v) {
     if (!visited.hasOwnProperty(v)) {
       dfs(v);
     }
   });
+
   return results;
 }

--- a/old-lib/alg/topsort.js
+++ b/old-lib/alg/topsort.js
@@ -1,0 +1,36 @@
+function topsort(g) {
+  var visited = {};
+  var stack = {};
+  var results = [];
+
+  function visit(node) {
+    if (stack.hasOwnProperty(node)) {
+      throw new CycleException();
+    }
+
+    if (!visited.hasOwnProperty(node)) {
+      stack[node] = true;
+      visited[node] = true;
+      g.predecessors(node).forEach(visit);
+      delete stack[node];
+      results.push(node);
+    }
+  }
+
+  g.sinks().forEach(visit);
+
+  if (Object.keys(visited).length !== g.nodeCount()) {
+    throw new CycleException();
+  }
+
+  return results;
+}
+
+class CycleException extends Error {
+  constructor() {
+    super(...arguments);
+  }
+}
+
+module.exports = topsort;
+topsort.CycleException = CycleException;

--- a/old-lib/data/priority-queue.js
+++ b/old-lib/data/priority-queue.js
@@ -1,0 +1,150 @@
+/**
+ * A min-priority queue data structure. This algorithm is derived from Cormen,
+ * et al., "Introduction to Algorithms". The basic idea of a min-priority
+ * queue is that you can efficiently (in O(1) time) get the smallest key in
+ * the queue. Adding and removing elements takes O(log n) time. A key can
+ * have its priority decreased in O(log n) time.
+ */
+class PriorityQueue {
+  #arr = [];
+  #keyIndices = {};
+
+  /**
+   * Returns the number of elements in the queue. Takes `O(1)` time.
+   */
+  size() {
+    return this.#arr.length;
+  }
+
+  /**
+   * Returns the keys that are in the queue. Takes `O(n)` time.
+   */
+  keys() {
+    return this.#arr.map(function(x) { return x.key; });
+  }
+
+  /**
+   * Returns `true` if **key** is in the queue and `false` if not.
+   */
+  has(key) {
+    return this.#keyIndices.hasOwnProperty(key);
+  }
+
+  /**
+   * Returns the priority for **key**. If **key** is not present in the queue
+   * then this function returns `undefined`. Takes `O(1)` time.
+   *
+   * @param {Object} key
+   */
+  priority(key) {
+    var index = this.#keyIndices[key];
+    if (index !== undefined) {
+      return this.#arr[index].priority;
+    }
+  }
+
+  /**
+   * Returns the key for the minimum element in this queue. If the queue is
+   * empty this function throws an Error. Takes `O(1)` time.
+   */
+  min() {
+    if (this.size() === 0) {
+      throw new Error("Queue underflow");
+    }
+    return this.#arr[0].key;
+  }
+
+  /**
+   * Inserts a new key into the priority queue. If the key already exists in
+   * the queue this function returns `false`; otherwise it will return `true`.
+   * Takes `O(n)` time.
+   *
+   * @param {Object} key the key to add
+   * @param {Number} priority the initial priority for the key
+   */
+  add(key, priority) {
+    var keyIndices = this.#keyIndices;
+    key = String(key);
+    if (!keyIndices.hasOwnProperty(key)) {
+      var arr = this.#arr;
+      var index = arr.length;
+      keyIndices[key] = index;
+      arr.push({key: key, priority: priority});
+      this.#decrease(index);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
+   */
+  removeMin() {
+    this.#swap(0, this.#arr.length - 1);
+    var min = this.#arr.pop();
+    delete this.#keyIndices[min.key];
+    this.#heapify(0);
+    return min.key;
+  }
+
+  /**
+   * Decreases the priority for **key** to **priority**. If the new priority is
+   * greater than the previous priority, this function will throw an Error.
+   *
+   * @param {Object} key the key for which to raise priority
+   * @param {Number} priority the new priority for the key
+   */
+  decrease(key, priority) {
+    var index = this.#keyIndices[key];
+    if (priority > this.#arr[index].priority) {
+      throw new Error("New priority is greater than current priority. " +
+          "Key: " + key + " Old: " + this.#arr[index].priority + " New: " + priority);
+    }
+    this.#arr[index].priority = priority;
+    this.#decrease(index);
+  }
+
+  #heapify(i) {
+    var arr = this.#arr;
+    var l = 2 * i;
+    var r = l + 1;
+    var largest = i;
+    if (l < arr.length) {
+      largest = arr[l].priority < arr[largest].priority ? l : largest;
+      if (r < arr.length) {
+        largest = arr[r].priority < arr[largest].priority ? r : largest;
+      }
+      if (largest !== i) {
+        this.#swap(i, largest);
+        this.#heapify(largest);
+      }
+    }
+  }
+
+  #decrease(index) {
+    var arr = this.#arr;
+    var priority = arr[index].priority;
+    var parent;
+    while (index !== 0) {
+      parent = index >> 1;
+      if (arr[parent].priority < priority) {
+        break;
+      }
+      this.#swap(index, parent);
+      index = parent;
+    }
+  }
+
+  #swap(i, j) {
+    var arr = this.#arr;
+    var keyIndices = this.#keyIndices;
+    var origArrI = arr[i];
+    var origArrJ = arr[j];
+    arr[i] = origArrJ;
+    arr[j] = origArrI;
+    keyIndices[origArrJ.key] = i;
+    keyIndices[origArrI.key] = j;
+  }
+}
+
+module.exports = PriorityQueue;

--- a/old-lib/graph.js
+++ b/old-lib/graph.js
@@ -1,0 +1,696 @@
+"use strict";
+
+var DEFAULT_EDGE_NAME = "\x00";
+var GRAPH_NODE = "\x00";
+var EDGE_KEY_DELIM = "\x01";
+
+// Implementation notes:
+//
+//  * Node id query functions should return string ids for the nodes
+//  * Edge id query functions should return an "edgeObj", edge object, that is
+//    composed of enough information to uniquely identify an edge: {v, w, name}.
+//  * Internally we use an "edgeId", a stringified form of the edgeObj, to
+//    reference edges. This is because we need a performant way to look these
+//    edges up and, object properties, which have string keys, are the closest
+//    we're going to get to a performant hashtable in JavaScript.
+
+class Graph {
+  #isDirected = true;
+  #isMultigraph = false;
+  #isCompound = false;
+
+  // Label for the graph itself
+  #label;
+
+  // Defaults to be set when creating a new node
+  #defaultNodeLabelFn = () => undefined;
+
+  // Defaults to be set when creating a new edge
+  #defaultEdgeLabelFn = () => undefined;
+
+  // v -> label
+  #nodes = {};
+
+  // v -> edgeObj
+  #in = {};
+
+  // u -> v -> Number
+  #preds = {};
+
+  // v -> edgeObj
+  #out = {};
+
+  // v -> w -> Number
+  #sucs = {};
+
+  // e -> edgeObj
+  #edgeObjs = {};
+
+  // e -> label
+  #edgeLabels = {};
+
+  /* Number of nodes in the graph. Should only be changed by the implementation. */
+  #nodeCount = 0;
+
+  /* Number of edges in the graph. Should only be changed by the implementation. */
+  #edgeCount = 0;
+
+  #parent;
+
+  #children;
+
+  constructor(opts) {
+    if (opts) {
+      this.#isDirected = opts.hasOwnProperty("directed") ? opts.directed : true;
+      this.#isMultigraph = opts.hasOwnProperty("multigraph") ? opts.multigraph : false;
+      this.#isCompound = opts.hasOwnProperty("compound") ? opts.compound : false;
+    }
+
+    if (this.#isCompound) {
+      // v -> parent
+      this.#parent = {};
+
+      // v -> children
+      this.#children = {};
+      this.#children[GRAPH_NODE] = {};
+    }
+  }
+
+  /* === Graph functions ========= */
+
+  /**
+   * Whether graph was created with 'directed' flag set to true or not.
+   */
+  isDirected() {
+    return this.#isDirected;
+  }
+
+  /**
+   * Whether graph was created with 'multigraph' flag set to true or not.
+   */
+  isMultigraph() {
+    return this.#isMultigraph;
+  }
+
+  /**
+   * Whether graph was created with 'compound' flag set to true or not.
+   */
+  isCompound() {
+    return this.#isCompound;
+  }
+
+  /**
+   * Sets the label of the graph.
+   */
+  setGraph(label) {
+    this.#label = label;
+    return this;
+  }
+
+  /**
+   * Gets the graph label.
+   */
+  graph() {
+    return this.#label;
+  }
+
+
+  /* === Node functions ========== */
+
+  /**
+   * Sets the default node label. If newDefault is a function, it will be
+   * invoked ach time when setting a label for a node. Otherwise, this label
+   * will be assigned as default label in case if no label was specified while
+   * setting a node.
+   * Complexity: O(1).
+   */
+  setDefaultNodeLabel(newDefault) {
+    this.#defaultNodeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultNodeLabelFn = () => newDefault;
+    }
+
+    return this;
+  }
+
+  /**
+   * Gets the number of nodes in the graph.
+   * Complexity: O(1).
+   */
+  nodeCount() {
+    return this.#nodeCount;
+  }
+
+  /**
+   * Gets all nodes of the graph. Note, the in case of compound graph subnodes are
+   * not included in list.
+   * Complexity: O(1).
+   */
+  nodes() {
+    return Object.keys(this.#nodes);
+  }
+
+  /**
+   * Gets list of nodes without in-edges.
+   * Complexity: O(|V|).
+   */
+  sources() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#in[v]).length === 0);
+  }
+
+  /**
+   * Gets list of nodes without out-edges.
+   * Complexity: O(|V|).
+   */
+  sinks() {
+    var self = this;
+    return this.nodes().filter(v => Object.keys(self.#out[v]).length === 0);
+  }
+
+  /**
+   * Invokes setNode method for each node in names list.
+   * Complexity: O(|names|).
+   */
+  setNodes(vs, value) {
+    var args = arguments;
+    var self = this;
+    vs.forEach(function(v) {
+      if (args.length > 1) {
+        self.setNode(v, value);
+      } else {
+        self.setNode(v);
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Creates or updates the value for the node v in the graph. If label is supplied
+   * it is set as the value for the node. If label is not supplied and the node was
+   * created by this call then the default node label will be assigned.
+   * Complexity: O(1).
+   */
+  setNode(v, value) {
+    if (this.#nodes.hasOwnProperty(v)) {
+      if (arguments.length > 1) {
+        this.#nodes[v] = value;
+      }
+      return this;
+    }
+
+    this.#nodes[v] = arguments.length > 1 ? value : this.#defaultNodeLabelFn(v);
+    if (this.#isCompound) {
+      this.#parent[v] = GRAPH_NODE;
+      this.#children[v] = {};
+      this.#children[GRAPH_NODE][v] = true;
+    }
+    this.#in[v] = {};
+    this.#preds[v] = {};
+    this.#out[v] = {};
+    this.#sucs[v] = {};
+    ++this.#nodeCount;
+    return this;
+  }
+
+  /**
+   * Gets the label of node with specified name.
+   * Complexity: O(|V|).
+   */
+  node(v) {
+    return this.#nodes[v];
+  }
+
+  /**
+   * Detects whether graph has a node with specified name or not.
+   */
+  hasNode(v) {
+    return this.#nodes.hasOwnProperty(v);
+  }
+
+  /**
+   * Remove the node with the name from the graph or do nothing if the node is not in
+   * the graph. If the node was removed this function also removes any incident
+   * edges.
+   * Complexity: O(1).
+   */
+  removeNode(v) {
+    var self = this;
+    if (this.#nodes.hasOwnProperty(v)) {
+      var removeEdge = e => self.removeEdge(self.#edgeObjs[e]);
+      delete this.#nodes[v];
+      if (this.#isCompound) {
+        this.#removeFromParentsChildList(v);
+        delete this.#parent[v];
+        this.children(v).forEach(function(child) {
+          self.setParent(child);
+        });
+        delete this.#children[v];
+      }
+      Object.keys(this.#in[v]).forEach(removeEdge);
+      delete this.#in[v];
+      delete this.#preds[v];
+      Object.keys(this.#out[v]).forEach(removeEdge);
+      delete this.#out[v];
+      delete this.#sucs[v];
+      --this.#nodeCount;
+    }
+    return this;
+  }
+
+  /**
+   * Sets node p as a parent for node v if it is defined, or removes the
+   * parent for v if p is undefined. Method throws an exception in case of
+   * invoking it in context of noncompound graph.
+   * Average-case complexity: O(1).
+   */
+  setParent(v, parent) {
+    if (!this.#isCompound) {
+      throw new Error("Cannot set parent in a non-compound graph");
+    }
+
+    if (parent === undefined) {
+      parent = GRAPH_NODE;
+    } else {
+      // Coerce parent to string
+      parent += "";
+      for (var ancestor = parent; ancestor !== undefined; ancestor = this.parent(ancestor)) {
+        if (ancestor === v) {
+          throw new Error("Setting " + parent+ " as parent of " + v +
+              " would create a cycle");
+        }
+      }
+
+      this.setNode(parent);
+    }
+
+    this.setNode(v);
+    this.#removeFromParentsChildList(v);
+    this.#parent[v] = parent;
+    this.#children[parent][v] = true;
+    return this;
+  }
+
+  #removeFromParentsChildList(v) {
+    delete this.#children[this.#parent[v]][v];
+  }
+
+  /**
+   * Gets parent node for node v.
+   * Complexity: O(1).
+   */
+  parent(v) {
+    if (this.#isCompound) {
+      var parent = this.#parent[v];
+      if (parent !== GRAPH_NODE) {
+        return parent;
+      }
+    }
+  }
+
+  /**
+   * Gets list of direct children of node v.
+   * Complexity: O(1).
+   */
+  children(v = GRAPH_NODE) {
+    if (this.#isCompound) {
+      var children = this.#children[v];
+      if (children) {
+        return Object.keys(children);
+      }
+    } else if (v === GRAPH_NODE) {
+      return this.nodes();
+    } else if (this.hasNode(v)) {
+      return [];
+    }
+  }
+
+  /**
+   * Return all nodes that are predecessors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  predecessors(v) {
+    var predsV = this.#preds[v];
+    if (predsV) {
+      return Object.keys(predsV);
+    }
+  }
+
+  /**
+   * Return all nodes that are successors of the specified node or undefined if node v is not in
+   * the graph. Behavior is undefined for undirected graphs - use neighbors instead.
+   * Complexity: O(|V|).
+   */
+  successors(v) {
+    var sucsV = this.#sucs[v];
+    if (sucsV) {
+      return Object.keys(sucsV);
+    }
+  }
+
+  /**
+   * Return all nodes that are predecessors or successors of the specified node or undefined if
+   * node v is not in the graph.
+   * Complexity: O(|V|).
+   */
+  neighbors(v) {
+    var preds = this.predecessors(v);
+    if (preds) {
+      const union = new Set(preds);
+      for (var succ of this.successors(v)) {
+        union.add(succ);
+      }
+
+      return Array.from(union.values());
+    }
+  }
+
+  isLeaf(v) {
+    var neighbors;
+    if (this.isDirected()) {
+      neighbors = this.successors(v);
+    } else {
+      neighbors = this.neighbors(v);
+    }
+    return neighbors.length === 0;
+  }
+
+  /**
+   * Creates new graph with nodes filtered via filter. Edges incident to rejected node
+   * are also removed. In case of compound graph, if parent is rejected by filter,
+   * than all its children are rejected too.
+   * Average-case complexity: O(|E|+|V|).
+   */
+  filterNodes(filter) {
+    var copy = new this.constructor({
+      directed: this.#isDirected,
+      multigraph: this.#isMultigraph,
+      compound: this.#isCompound
+    });
+
+    copy.setGraph(this.graph());
+
+    var self = this;
+    Object.entries(this.#nodes).forEach(function([v, value]) {
+      if (filter(v)) {
+        copy.setNode(v, value);
+      }
+    });
+
+    Object.values(this.#edgeObjs).forEach(function(e) {
+      if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
+        copy.setEdge(e, self.edge(e));
+      }
+    });
+
+    var parents = {};
+    function findParent(v) {
+      var parent = self.parent(v);
+      if (parent === undefined || copy.hasNode(parent)) {
+        parents[v] = parent;
+        return parent;
+      } else if (parent in parents) {
+        return parents[parent];
+      } else {
+        return findParent(parent);
+      }
+    }
+
+    if (this.#isCompound) {
+      copy.nodes().forEach(v => copy.setParent(v, findParent(v)));
+    }
+
+    return copy;
+  }
+
+  /* === Edge functions ========== */
+
+  /**
+   * Sets the default edge label or factory function. This label will be
+   * assigned as default label in case if no label was specified while setting
+   * an edge or this function will be invoked each time when setting an edge
+   * with no label specified and returned value * will be used as a label for edge.
+   * Complexity: O(1).
+   */
+  setDefaultEdgeLabel(newDefault) {
+    this.#defaultEdgeLabelFn = newDefault;
+    if (typeof newDefault !== 'function') {
+      this.#defaultEdgeLabelFn = () => newDefault;
+    }
+
+    return this;
+  }
+
+  /**
+   * Gets the number of edges in the graph.
+   * Complexity: O(1).
+   */
+  edgeCount() {
+    return this.#edgeCount;
+  }
+
+  /**
+   * Gets edges of the graph. In case of compound graph subgraphs are not considered.
+   * Complexity: O(|E|).
+   */
+  edges() {
+    return Object.values(this.#edgeObjs);
+  }
+
+  /**
+   * Establish an edges path over the nodes in nodes list. If some edge is already
+   * exists, it will update its label, otherwise it will create an edge between pair
+   * of nodes with label provided or default label if no label provided.
+   * Complexity: O(|nodes|).
+   */
+  setPath(vs, value) {
+    var self = this;
+    var args = arguments;
+    vs.reduce(function(v, w) {
+      if (args.length > 1) {
+        self.setEdge(v, w, value);
+      } else {
+        self.setEdge(v, w);
+      }
+      return w;
+    });
+    return this;
+  }
+
+  /**
+   * Creates or updates the label for the edge (v, w) with the optionally supplied
+   * name. If label is supplied it is set as the value for the edge. If label is not
+   * supplied and the edge was created by this call then the default edge label will
+   * be assigned. The name parameter is only useful with multigraphs.
+   */
+  setEdge() {
+    var v, w, name, value;
+    var valueSpecified = false;
+    var arg0 = arguments[0];
+
+    if (typeof arg0 === "object" && arg0 !== null && "v" in arg0) {
+      v = arg0.v;
+      w = arg0.w;
+      name = arg0.name;
+      if (arguments.length === 2) {
+        value = arguments[1];
+        valueSpecified = true;
+      }
+    } else {
+      v = arg0;
+      w = arguments[1];
+      name = arguments[3];
+      if (arguments.length > 2) {
+        value = arguments[2];
+        valueSpecified = true;
+      }
+    }
+
+    v = "" + v;
+    w = "" + w;
+    if (name !== undefined) {
+      name = "" + name;
+    }
+
+    var e = edgeArgsToId(this.#isDirected, v, w, name);
+    if (this.#edgeLabels.hasOwnProperty(e)) {
+      if (valueSpecified) {
+        this.#edgeLabels[e] = value;
+      }
+      return this;
+    }
+
+    if (name !== undefined && !this.#isMultigraph) {
+      throw new Error("Cannot set a named edge when isMultigraph = false");
+    }
+
+    // It didn't exist, so we need to create it.
+    // First ensure the nodes exist.
+    this.setNode(v);
+    this.setNode(w);
+
+    this.#edgeLabels[e] = valueSpecified ? value : this.#defaultEdgeLabelFn(v, w, name);
+
+    var edgeObj = edgeArgsToObj(this.#isDirected, v, w, name);
+    // Ensure we add undirected edges in a consistent way.
+    v = edgeObj.v;
+    w = edgeObj.w;
+
+    Object.freeze(edgeObj);
+    this.#edgeObjs[e] = edgeObj;
+    incrementOrInitEntry(this.#preds[w], v);
+    incrementOrInitEntry(this.#sucs[v], w);
+    this.#in[w][e] = edgeObj;
+    this.#out[v][e] = edgeObj;
+    this.#edgeCount++;
+    return this;
+  }
+
+  /**
+   * Gets the label for the specified edge.
+   * Complexity: O(1).
+   */
+  edge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    return this.#edgeLabels[e];
+  }
+
+  /**
+   * Gets the label for the specified edge and converts it to an object.
+   * Complexity: O(1)
+   */
+  edgeAsObj() {
+    const edge = this.edge(...arguments);
+    if (typeof edge !== "object") {
+      return {label: edge};
+    }
+
+    return edge;
+  }
+
+  /**
+   * Detects whether the graph contains specified edge or not. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  hasEdge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    return this.#edgeLabels.hasOwnProperty(e);
+  }
+
+  /**
+   * Removes the specified edge from the graph. No subgraphs are considered.
+   * Complexity: O(1).
+   */
+  removeEdge(v, w, name) {
+    var e = (arguments.length === 1
+      ? edgeObjToId(this.#isDirected, arguments[0])
+      : edgeArgsToId(this.#isDirected, v, w, name));
+    var edge = this.#edgeObjs[e];
+    if (edge) {
+      v = edge.v;
+      w = edge.w;
+      delete this.#edgeLabels[e];
+      delete this.#edgeObjs[e];
+      decrementOrRemoveEntry(this.#preds[w], v);
+      decrementOrRemoveEntry(this.#sucs[v], w);
+      delete this.#in[w][e];
+      delete this.#out[v][e];
+      this.#edgeCount--;
+    }
+    return this;
+  }
+
+  /**
+   * Return all edges that point to the node v. Optionally filters those edges down to just those
+   * coming from node u. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  inEdges(v, u) {
+    var inV = this.#in[v];
+    if (inV) {
+      var edges = Object.values(inV);
+      if (!u) {
+        return edges;
+      }
+      return edges.filter(edge => edge.v === u);
+    }
+  }
+
+  /**
+   * Return all edges that are pointed at by node v. Optionally filters those edges down to just
+   * those point to w. Behavior is undefined for undirected graphs - use nodeEdges instead.
+   * Complexity: O(|E|).
+   */
+  outEdges(v, w) {
+    var outV = this.#out[v];
+    if (outV) {
+      var edges = Object.values(outV);
+      if (!w) {
+        return edges;
+      }
+      return edges.filter(edge => edge.w === w);
+    }
+  }
+
+  /**
+   * Returns all edges to or from node v regardless of direction. Optionally filters those edges
+   * down to just those between nodes v and w regardless of direction.
+   * Complexity: O(|E|).
+   */
+  nodeEdges(v, w) {
+    var inEdges = this.inEdges(v, w);
+    if (inEdges) {
+      return inEdges.concat(this.outEdges(v, w));
+    }
+  }
+}
+
+function incrementOrInitEntry(map, k) {
+  if (map[k]) {
+    map[k]++;
+  } else {
+    map[k] = 1;
+  }
+}
+
+function decrementOrRemoveEntry(map, k) {
+  if (!--map[k]) { delete map[k]; }
+}
+
+function edgeArgsToId(isDirected, v_, w_, name) {
+  var v = "" + v_;
+  var w = "" + w_;
+  if (!isDirected && v > w) {
+    var tmp = v;
+    v = w;
+    w = tmp;
+  }
+  return v + EDGE_KEY_DELIM + w + EDGE_KEY_DELIM +
+             (name === undefined ? DEFAULT_EDGE_NAME : name);
+}
+
+function edgeArgsToObj(isDirected, v_, w_, name) {
+  var v = "" + v_;
+  var w = "" + w_;
+  if (!isDirected && v > w) {
+    var tmp = v;
+    v = w;
+    w = tmp;
+  }
+  var edgeObj =  { v: v, w: w };
+  if (name) {
+    edgeObj.name = name;
+  }
+  return edgeObj;
+}
+
+function edgeObjToId(isDirected, edgeObj) {
+  return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
+}
+
+module.exports = Graph;

--- a/old-lib/index.js
+++ b/old-lib/index.js
@@ -1,0 +1,5 @@
+// Includes only the "core" of graphlib
+module.exports = {
+  Graph: require("./graph"),
+  version: require("./version")
+};

--- a/old-lib/json.js
+++ b/old-lib/json.js
@@ -1,12 +1,10 @@
-"use strict";
+var Graph = require("./graph");
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.read = read;
-exports.write = write;
-var _graph = _interopRequireDefault(require("./graph.js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+module.exports = {
+  write: write,
+  read: read
+};
+
 /**
  * Creates a JSON representation of the graph that can be serialized to a string with
  * JSON.stringify. The graph can later be restored using json.read.
@@ -21,18 +19,18 @@ function write(g) {
     nodes: writeNodes(g),
     edges: writeEdges(g)
   };
+
   if (g.graph() !== undefined) {
     json.value = structuredClone(g.graph());
   }
   return json;
 }
+
 function writeNodes(g) {
-  return g.nodes().map(function (v) {
+  return g.nodes().map(function(v) {
     var nodeValue = g.node(v);
     var parent = g.parent(v);
-    var node = {
-      v: v
-    };
+    var node = { v: v };
     if (nodeValue !== undefined) {
       node.value = nodeValue;
     }
@@ -42,13 +40,11 @@ function writeNodes(g) {
     return node;
   });
 }
+
 function writeEdges(g) {
-  return g.edges().map(function (e) {
+  return g.edges().map(function(e) {
     var edgeValue = g.edge(e);
-    var edge = {
-      v: e.v,
-      w: e.w
-    };
+    var edge = { v: e.v, w: e.w };
     if (e.name !== undefined) {
       edge.name = e.name;
     }
@@ -70,19 +66,15 @@ function writeEdges(g) {
  * // [ { v: 'a', w: 'b' } ]
  */
 function read(json) {
-  var g = new _graph["default"](json.options).setGraph(json.value);
-  json.nodes.forEach(function (entry) {
+  var g = new Graph(json.options).setGraph(json.value);
+  json.nodes.forEach(function(entry) {
     g.setNode(entry.v, entry.value);
     if (entry.parent) {
       g.setParent(entry.v, entry.parent);
     }
   });
-  json.edges.forEach(function (entry) {
-    g.setEdge({
-      v: entry.v,
-      w: entry.w,
-      name: entry.name
-    }, entry.value);
+  json.edges.forEach(function(entry) {
+    g.setEdge({ v: entry.v, w: entry.w, name: entry.name }, entry.value);
   });
   return g;
 }

--- a/old-lib/version.js
+++ b/old-lib/version.js
@@ -1,0 +1,1 @@
+module.exports = '2.1.14-pre';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "2.1.14-pre",
       "license": "MIT",
       "devDependencies": {
+        "@babel/cli": "^7.23.9",
+        "@babel/core": "^7.23.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+        "@babel/preset-env": "^7.23.9",
         "benchmark": "2.1.4",
         "browserify": "16.5.1",
         "chai": "^4.3.6",
@@ -45,13 +49,70 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+    "node_modules/@babel/cli": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
+      "integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "commander": "^4.0.1",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/@babel/cli/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -59,33 +120,35 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.0",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.0",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
-        "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -96,25 +159,27 @@
       }
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -124,9 +189,10 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -136,16 +202,70 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.20.7",
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.21.3",
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
+      "integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+      "integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
+        "@babel/helper-optimise-call-expression": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -154,12 +274,55 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
+      "integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "regexpu-core": "^5.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
+      "integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.22.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -196,41 +359,123 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
+      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.21.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.20.2",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.2",
-        "@babel/types": "^7.21.2"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.20.2",
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
+      "integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
+      "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-wrap-function": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-optimise-call-expression": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -249,9 +494,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -267,30 +512,46 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.21.0",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
+      "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.22.19"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.0",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0"
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -302,9 +563,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -313,35 +574,1246 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
+      "integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
+      "integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/plugin-transform-optional-chaining": "^7.23.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
+      "integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
+      "integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
+      "integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
+      "integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+      "integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-remap-async-to-generator": "^7.22.20",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
+      "integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-remap-async-to-generator": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
+      "integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
+      "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
+      "integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+      "integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
+      "integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/template": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
+      "integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
+      "integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
+      "integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
+      "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
+      "integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
+      "integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
+      "integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
+      "integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
+      "integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
+      "integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
+      "integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
+      "integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
+      "integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
+      "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+      "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
+      "integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
+      "integrity": "sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
+      "integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
+      "integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
+      "integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
+      "integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.23.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
+      "integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
+      "integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
+      "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
+      "integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
+      "integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
+      "integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
+      "integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
+      "integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "regenerator-transform": "^0.15.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
+      "integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
+      "integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
+      "integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
+      "integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
+      "integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
+      "integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
+      "integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
+      "integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
+      "integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
+      "integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+      "integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.23.3",
+        "@babel/plugin-syntax-import-attributes": "^7.23.3",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.23.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.9",
+        "@babel/plugin-transform-async-to-generator": "^7.23.3",
+        "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
+        "@babel/plugin-transform-block-scoping": "^7.23.4",
+        "@babel/plugin-transform-class-properties": "^7.23.3",
+        "@babel/plugin-transform-class-static-block": "^7.23.4",
+        "@babel/plugin-transform-classes": "^7.23.8",
+        "@babel/plugin-transform-computed-properties": "^7.23.3",
+        "@babel/plugin-transform-destructuring": "^7.23.3",
+        "@babel/plugin-transform-dotall-regex": "^7.23.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.23.3",
+        "@babel/plugin-transform-dynamic-import": "^7.23.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.23.4",
+        "@babel/plugin-transform-for-of": "^7.23.6",
+        "@babel/plugin-transform-function-name": "^7.23.3",
+        "@babel/plugin-transform-json-strings": "^7.23.4",
+        "@babel/plugin-transform-literals": "^7.23.3",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.23.3",
+        "@babel/plugin-transform-modules-amd": "^7.23.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.23.9",
+        "@babel/plugin-transform-modules-umd": "^7.23.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
+        "@babel/plugin-transform-new-target": "^7.23.3",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+        "@babel/plugin-transform-numeric-separator": "^7.23.4",
+        "@babel/plugin-transform-object-rest-spread": "^7.23.4",
+        "@babel/plugin-transform-object-super": "^7.23.3",
+        "@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+        "@babel/plugin-transform-optional-chaining": "^7.23.4",
+        "@babel/plugin-transform-parameters": "^7.23.3",
+        "@babel/plugin-transform-private-methods": "^7.23.3",
+        "@babel/plugin-transform-private-property-in-object": "^7.23.4",
+        "@babel/plugin-transform-property-literals": "^7.23.3",
+        "@babel/plugin-transform-regenerator": "^7.23.3",
+        "@babel/plugin-transform-reserved-words": "^7.23.3",
+        "@babel/plugin-transform-shorthand-properties": "^7.23.3",
+        "@babel/plugin-transform-spread": "^7.23.3",
+        "@babel/plugin-transform-sticky-regex": "^7.23.3",
+        "@babel/plugin-transform-template-literals": "^7.23.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.23.3",
+        "@babel/plugin-transform-unicode-escapes": "^7.23.3",
+        "@babel/plugin-transform-unicode-property-regex": "^7.23.3",
+        "@babel/plugin-transform-unicode-regex": "^7.23.3",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
+        "core-js-compat": "^3.31.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
+      "dev": true
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -350,19 +1822,20 @@
     },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -605,6 +2078,13 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -832,6 +2312,54 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
+      "integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+      "integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "core-js-compat": "^3.34.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
+      "integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1162,7 +2690,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "dev": true,
       "funding": [
         {
@@ -1172,14 +2702,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1271,7 +2804,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001460",
+      "version": "1.0.30001581",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
+      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
       "dev": true,
       "funding": [
         {
@@ -1281,9 +2816,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chai": {
       "version": "4.3.7",
@@ -1415,6 +2953,15 @@
         "source-map": "~0.5.3"
       }
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "dev": true,
@@ -1497,6 +3044,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+      "integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.22.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -1845,9 +3405,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.317",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.651",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.651.tgz",
+      "integrity": "sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -2502,6 +4063,12 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -2520,9 +4087,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2720,6 +4291,18 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -2961,6 +4544,18 @@
       "version": "1.1.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3220,8 +4815,9 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3532,6 +5128,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "dev": true,
@@ -3633,8 +5235,9 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -4026,9 +5629,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4459,8 +6063,9 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4471,6 +6076,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pkg-dir": {
@@ -4730,6 +6344,39 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
+      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
+    },
+    "node_modules/regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "dev": true,
@@ -4739,6 +6386,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/release-zalgo": {
@@ -4783,11 +6468,20 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.12.0",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -5008,6 +6702,15 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/socket.io": {
       "version": "4.6.1",
@@ -5283,6 +6986,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/syntax-error": {
       "version": "1.4.0",
       "dev": true,
@@ -5346,8 +7061,9 @@
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -5472,6 +7188,46 @@
         "undeclared-identifiers": "bin.js"
       }
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "dev": true,
@@ -5489,7 +7245,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -5499,15 +7257,18 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -5728,8 +7489,9 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -5791,65 +7553,116 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+    "@babel/cli": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
+      "integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.22.13",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       }
     },
     "@babel/compat-data": {
-      "version": "7.21.0",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.21.0",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
-        "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "dependencies": {
         "convert-source-map": {
-          "version": "1.9.0",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "dependencies": {
         "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
           "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
@@ -5859,21 +7672,100 @@
         }
       }
     },
-    "@babel/helper-compilation-targets": {
-      "version": "7.20.7",
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.21.3",
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
+      "integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.15"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+      "integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
+        "@babel/helper-optimise-call-expression": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
+      "integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "regexpu-core": "^5.3.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
+      "integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.22.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5901,32 +7793,90 @@
         "@babel/types": "^7.22.5"
       }
     },
-    "@babel/helper-module-imports": {
-      "version": "7.18.6",
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
+      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.23.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.15"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.21.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.20.2",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.2",
-        "@babel/types": "^7.21.2"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "dev": true
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
+      "integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-wrap-function": "^7.22.20"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-optimise-call-expression": "^7.22.5"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.20.2",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.2"
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -5939,9 +7889,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
@@ -5951,22 +7901,37 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.21.0",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true
     },
-    "@babel/helpers": {
-      "version": "7.21.0",
+    "@babel/helper-wrap-function": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
+      "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0"
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.22.19"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
       }
     },
     "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -5975,53 +7940,869 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "dev": true
     },
-    "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
+      "integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
-    "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
+      "integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/plugin-transform-optional-chaining": "^7.23.3"
+      }
+    },
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
+      "integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-import-assertions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
+      "integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-syntax-import-attributes": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
+      "integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
+      "integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-async-generator-functions": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+      "integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-remap-async-to-generator": "^7.22.20",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
+      "integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-remap-async-to-generator": "^7.22.20"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
+      "integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
+      "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-class-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
+      "integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-class-static-block": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+      "integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "globals": {
           "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
+      "integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/template": "^7.22.15"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
+      "integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
+      "integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
+      "integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-dynamic-import": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
+      "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
+      "integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-export-namespace-from": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
+      "integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
+      "integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
+      "integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-json-strings": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
+      "integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
+      "integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
+      "integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
+      "integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
+      "integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
+      "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+      "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
+      "integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
+      "integrity": "sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
+      "integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
+      "integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-numeric-separator": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
+      "integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-object-rest-spread": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
+      "integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.23.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
+      "integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20"
+      }
+    },
+    "@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
+      "integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-optional-chaining": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
+      "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
+      "integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-private-methods": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
+      "integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-private-property-in-object": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
+      "integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
+      "integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
+      "integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "regenerator-transform": "^0.15.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
+      "integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
+      "integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
+      "integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
+      "integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
+      "integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
+      "integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
+      "integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
+      "integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
+      "integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
+      "integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+      "integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.23.3",
+        "@babel/plugin-syntax-import-attributes": "^7.23.3",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.23.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.9",
+        "@babel/plugin-transform-async-to-generator": "^7.23.3",
+        "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
+        "@babel/plugin-transform-block-scoping": "^7.23.4",
+        "@babel/plugin-transform-class-properties": "^7.23.3",
+        "@babel/plugin-transform-class-static-block": "^7.23.4",
+        "@babel/plugin-transform-classes": "^7.23.8",
+        "@babel/plugin-transform-computed-properties": "^7.23.3",
+        "@babel/plugin-transform-destructuring": "^7.23.3",
+        "@babel/plugin-transform-dotall-regex": "^7.23.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.23.3",
+        "@babel/plugin-transform-dynamic-import": "^7.23.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.23.4",
+        "@babel/plugin-transform-for-of": "^7.23.6",
+        "@babel/plugin-transform-function-name": "^7.23.3",
+        "@babel/plugin-transform-json-strings": "^7.23.4",
+        "@babel/plugin-transform-literals": "^7.23.3",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.23.3",
+        "@babel/plugin-transform-modules-amd": "^7.23.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.23.9",
+        "@babel/plugin-transform-modules-umd": "^7.23.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
+        "@babel/plugin-transform-new-target": "^7.23.3",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+        "@babel/plugin-transform-numeric-separator": "^7.23.4",
+        "@babel/plugin-transform-object-rest-spread": "^7.23.4",
+        "@babel/plugin-transform-object-super": "^7.23.3",
+        "@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+        "@babel/plugin-transform-optional-chaining": "^7.23.4",
+        "@babel/plugin-transform-parameters": "^7.23.3",
+        "@babel/plugin-transform-private-methods": "^7.23.3",
+        "@babel/plugin-transform-private-property-in-object": "^7.23.4",
+        "@babel/plugin-transform-property-literals": "^7.23.3",
+        "@babel/plugin-transform-regenerator": "^7.23.3",
+        "@babel/plugin-transform-reserved-words": "^7.23.3",
+        "@babel/plugin-transform-shorthand-properties": "^7.23.3",
+        "@babel/plugin-transform-spread": "^7.23.3",
+        "@babel/plugin-transform-sticky-regex": "^7.23.3",
+        "@babel/plugin-transform-template-literals": "^7.23.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.23.3",
+        "@babel/plugin-transform-unicode-escapes": "^7.23.3",
+        "@babel/plugin-transform-unicode-property-regex": "^7.23.3",
+        "@babel/plugin-transform-unicode-regex": "^7.23.3",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
+        "core-js-compat": "^3.31.0",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
+      "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
@@ -6176,6 +8957,13 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6339,6 +9127,44 @@
     "assertion-error": {
       "version": "1.1.0",
       "dev": true
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
+      "integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+      "integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "core-js-compat": "^3.34.0"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
+      "integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.5.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -6605,13 +9431,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.5",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "buffer": {
@@ -6669,7 +9497,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001460",
+      "version": "1.0.30001581",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
+      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
       "dev": true
     },
     "chai": {
@@ -6768,6 +9598,12 @@
         "source-map": "~0.5.3"
       }
     },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "dev": true
@@ -6831,6 +9667,15 @@
     "cookie": {
       "version": "0.4.2",
       "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+      "integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.22.2"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7081,7 +9926,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.317",
+      "version": "1.4.651",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.651.tgz",
+      "integrity": "sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==",
       "dev": true
     },
     "elliptic": {
@@ -7499,6 +10346,12 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
@@ -7509,7 +10362,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "gensync": {
@@ -7633,6 +10488,15 @@
           "version": "0.8.1",
           "dev": true
         }
+      }
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -7798,6 +10662,15 @@
       "version": "1.1.6",
       "dev": true
     },
+    "is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.0"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "dev": true
@@ -7957,6 +10830,8 @@
     },
     "jsesc": {
       "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "jshint": {
@@ -8169,6 +11044,12 @@
       "version": "4.17.21",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "dev": true
@@ -8240,6 +11121,8 @@
     },
     "lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
@@ -8489,7 +11372,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.10",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "normalize-path": {
@@ -8778,10 +11663,18 @@
     },
     "picocolors": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
     "pkg-dir": {
@@ -8956,9 +11849,70 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
+      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "dev": true
+    },
+    "regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      }
+    },
+    "regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+          "dev": true
+        }
+      }
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -8984,10 +11938,14 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -9125,6 +12083,12 @@
     },
     "simple-concat": {
       "version": "1.0.0",
+      "dev": true
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
     "socket.io": {
@@ -9324,6 +12288,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "syntax-error": {
       "version": "1.4.0",
       "dev": true,
@@ -9372,6 +12342,8 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -9439,6 +12411,34 @@
         "xtend": "^4.0.1"
       }
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.2",
       "dev": true
@@ -9448,7 +12448,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -9598,6 +12600,8 @@
     },
     "yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/core": "^7.23.9",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
         "@babel/preset-env": "^7.23.9",
+        "babel-plugin-add-module-exports": "^1.0.4",
         "benchmark": "2.1.4",
         "browserify": "16.5.1",
         "chai": "^4.3.6",
@@ -2313,6 +2314,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/babel-plugin-add-module-exports": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+      "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
+      "dev": true
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.8",
@@ -9126,6 +9133,12 @@
     },
     "assertion-error": {
       "version": "1.1.0",
+      "dev": true
+    },
+    "babel-plugin-add-module-exports": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+      "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
       "dev": true
     },
     "babel-plugin-polyfill-corejs2": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "lint": "make lint",
     "test": "make test"
   },
+  "module": "./mjs-lib/index.js",
+  "exports": {
+    "import": "./mjs-lib/index.js",
+    "require": "./lib/index.js"
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   "module": "./mjs-lib/index.js",
   "exports": {
     "import": "./mjs-lib/index.js",
-    "require": "./lib/index.js"
+    "require": "./index.js"
   },
   "files": [
     "index.js",
     "index.d.ts",
     "dist/",
-    "lib/"
+    "lib/",
+    "mjs-lib/"
   ],
   "engines": {
     "node": ">17.0.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.23.9",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-env": "^7.23.9",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "benchmark": "2.1.4",
     "browserify": "16.5.1",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "algorithms"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.23.9",
+    "@babel/core": "^7.23.9",
+    "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+    "@babel/preset-env": "^7.23.9",
     "benchmark": "2.1.4",
     "browserify": "16.5.1",
     "chai": "^4.3.6",

--- a/src/release/make-bower.json.js
+++ b/src/release/make-bower.json.js
@@ -21,6 +21,8 @@ var template = {
     "index.js",
     "karma*",
     "lib/**",
+    "mjs-lib/**",
+    "old-lib/**",
     "package.json",
     "src/**",
     "test/**"

--- a/src/release/make-version.js
+++ b/src/release/make-version.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 var package = require('../../package.json');
-console.log('module.exports = \'' + package.version + '\';');
+console.log('export default \'' + package.version + '\';');

--- a/src/release/release.sh
+++ b/src/release/release.sh
@@ -59,7 +59,7 @@ echo Published to npm
 
 # Update patch level version + commit
 ./src/release/bump-version.js
-make lib/version.js
+make mjs-lib/version.js
 git commit package.json lib/version.js -m "Bump version and set as pre-release"
 git push origin
 echo Updated patch version


### PR DESCRIPTION
Your code is very well organized! I plan on doing this for dagre today, as well.

If you accept these changes, I would imagine we still need to package and release to npm if thats something y'all do.

### What I did

1. I created a `mjs-lib` folder which now contains the _actual source_ converted to use ESM `import` syntax instead of CJS `require` syntax. _see [note](#changes-to-source) for how_
4. I installed some babel plugins (see `./babelrc` for their names) and added them to `--save-dev`. _see [note](#babel-strategy)_
5. I create `make convert convert-clean %deps`  target which runs the plugins on `mjs-lib/` and reproduces the commonjs style `lib/`. The Makefile is fully aware of the changes, and all targets dependendent on a proper conversion do so. Version now goes to mjs-lib, not-lib.
6. I changed the linting to lint the `mjs-lib/` folder and not the `lib/` folder.
7. I changed `package.json` to indicate where require files and where esm files are. 

Tests pass. I currently have the old source saved in `old-lib`.


#### Why it's a good strategy

1. it is easier to go from esm --> commonjs than the other way around, since esm is stricter
2. Having source as esm will improve any treeshaking for your downstream.

#### Changes to source

Modification to source code are very straight forward.

```javascript
module.exports.thing = thing     --> export thing
module.exports.name = thing      --> export thing as name
module.exports = thing           --> export default thing
const name = require("./thing")  --> import name from "./thing.js"
```

#### Babel strategy

Babel is not used to transpile any code to other versions of javascript! It is only used to convert `esm` back to `commonjs`.