### PR TITLE
Fix TypeScript type definition syntax error in dijkstraAll

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -486,7 +486,7 @@ export namespace alg {
     graph: Graph,
     weightFn?: (e: Edge) => number,
     edgeFn?: (v: string) => Edge[],
-  ): { : { [node: string]: Path } };
+  ): { [source: string]: { [node: string]: Path } };
 
   /**
    * Given a Graph, graph, this function returns all nodes that are part of a cycle. As there


### PR DESCRIPTION
### Issue
The _dijkstraAll_ function had a malformed return type in _index.d.ts_ (line 489) that caused TypeScript compilation errors.

### Change
Fixed the return type signature from:
`typescript): { : { [node: string]: Path } };`
to:
`typescript): { [source: string]: { [node: string]: Path } };`

### Impact
Resolves TypeScript errors when using the library with TypeScript projects
The return type now correctly represents that _dijkstraAll_ returns an object mapping source nodes to their shortest path results
Aligns the type definition with the actual JavaScript implementation in _lib/alg/dijkstra-all.js_

### Errors Fixed
TS1131: Property or signature expected
TS1005: ',' expected
TS1128: Declaration or statement expected