### PR TITLE
Fix findCycles missing self-loops created with named edges

### DIFF
--- a/lib/alg/find-cycles.ts
+++ b/lib/alg/find-cycles.ts
@@ -1,4 +1,5 @@
 import {Graph} from '../graph';
+import type {Edge} from '../types';
 import {tarjan} from './tarjan';
 
 /**
@@ -14,6 +15,10 @@ import {tarjan} from './tarjan';
  */
 export function findCycles(graph: Graph): string[][] {
     return tarjan(graph).filter(function (cmpt) {
-        return cmpt.length > 1 || (cmpt.length === 1 && graph.hasEdge(cmpt[0]!, cmpt[0]!));
+        // A single-node component is a cycle iff the node has a self-loop. We check via outEdges
+        // rather than hasEdge(v, v) because the latter only matches the default (unnamed) edge and
+        // would miss a named self-loop edge in a multigraph.
+        return cmpt.length > 1
+            || (cmpt.length === 1 && (graph.outEdges(cmpt[0]!, cmpt[0]!) as Edge[]).length > 0);
     });
 }

--- a/test/alg/find-cycles-test.ts
+++ b/test/alg/find-cycles-test.ts
@@ -30,6 +30,13 @@ describe("alg.findCycles", () => {
         expect(sort(findCycles(g))).toEqual([["a", "b", "c"]]);
     });
 
+    it("detects a self-loop created with a named edge in a multigraph", () => {
+        const g = new Graph({multigraph: true});
+        g.setNode("a");
+        g.setEdge("a", "a", "label", "name");
+        expect(sort(findCycles(g))).toEqual([["a"]]);
+    });
+
     it("returns multiple entries for multiple cycles", () => {
         const g = new Graph();
         g.setPath(["a", "b", "a"]);


### PR DESCRIPTION
Fixes #111.

`findCycles` decides whether a single-node strongly-connected component is a cycle by calling `graph.hasEdge(v, v)`. That overload only matches the **default (unnamed)** edge, so a self-loop added as a named edge in a multigraph (`setEdge(v, v, label, name)`) is missed and the node is wrongly reported as cycle-free.

Switched the check to `graph.outEdges(v, v)`, which returns every edge between `v` and itself regardless of name, so any self-loop is detected. Behaviour for unnamed self-loops is unchanged.

Repro (before this PR returns `[]`):
```js
const g = new Graph({ multigraph: true });
g.setEdge('a', 'a', 'label', 'name');
findCycles(g); // expected [['a']]
```

Added a regression test (fails without the fix). Full suite (256 tests), typecheck and lint all pass.